### PR TITLE
Add events tab with invite/open event flows

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
+from datetime import datetime, timedelta
 from sqlalchemy import inspect
 from flask_socketio import SocketIO
 
@@ -34,7 +35,7 @@ def load_user(user_id):
 
 
 def ensure_test_data():
-    from .database import DegreeCategory, DegreeOption, Notification, User
+    from .database import DegreeCategory, DegreeOption, Event, EventAttendee, Notification, User
 
     existing_tables = set(inspect(db.engine).get_table_names())
     required_tables = {"user", "notification", "degree_category", "degree_option"}
@@ -148,6 +149,7 @@ def ensure_test_data():
             major="Software Engineering",
             username="Mineth1",
         )
+        test_user.set_password("Mineth1@123")
         db.session.add(test_user)
         db.session.commit()
 
@@ -178,6 +180,95 @@ def ensure_test_data():
             ]
         )
         db.session.commit()
+
+    if {"event", "event_attendee"}.issubset(existing_tables):
+        creator = User.query.filter_by(username="Mineth1").first() or User.query.first()
+        participant = None
+        if creator is not None:
+            participant = User.query.filter_by(username="alice1").first() or User.query.filter(User.id != creator.id).first()
+
+        if creator and Event.query.filter(Event.title.like("[DEMO] %")).count() == 0:
+            start_base = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+
+            invite_event = Event(
+                creator_user_id=creator.id,
+                title="[DEMO] CITS Revision Group",
+                description="Weekly exam revision planning.",
+                location_or_link="Reid Library Room 2",
+                visibility_mode="invite_only",
+                max_attendees=6,
+                start_at=start_base + timedelta(days=1),
+                end_at=start_base + timedelta(days=1, hours=2),
+                status="scheduled",
+            )
+            db.session.add(invite_event)
+            db.session.flush()
+            db.session.add(
+                EventAttendee(
+                    event_id=invite_event.id,
+                    user_id=creator.id,
+                    invite_status="accepted",
+                    responded_at=datetime.utcnow(),
+                )
+            )
+
+            if participant:
+                db.session.add(EventAttendee(event_id=invite_event.id, user_id=participant.id, invite_status="invited"))
+
+            open_event = Event(
+                creator_user_id=creator.id,
+                title="[DEMO] Open Study Sprint",
+                description="Drop-in problem solving session.",
+                location_or_link="EZONE common area",
+                visibility_mode="open",
+                max_attendees=4,
+                start_at=start_base + timedelta(days=2),
+                end_at=start_base + timedelta(days=2, hours=2),
+                status="scheduled",
+            )
+            db.session.add(open_event)
+            db.session.flush()
+            db.session.add(
+                EventAttendee(
+                    event_id=open_event.id,
+                    user_id=creator.id,
+                    invite_status="accepted",
+                    responded_at=datetime.utcnow(),
+                )
+            )
+            if participant:
+                db.session.add(
+                    EventAttendee(
+                        event_id=open_event.id,
+                        user_id=participant.id,
+                        invite_status="accepted",
+                        responded_at=datetime.utcnow(),
+                    )
+                )
+
+            past_event = Event(
+                creator_user_id=creator.id,
+                title="[DEMO] Past Project Debrief",
+                description="Retro and next steps.",
+                location_or_link="Online",
+                visibility_mode="invite_only",
+                max_attendees=5,
+                start_at=start_base - timedelta(days=2, hours=2),
+                end_at=start_base - timedelta(days=2),
+                status="scheduled",
+            )
+            db.session.add(past_event)
+            db.session.flush()
+            db.session.add(
+                EventAttendee(
+                    event_id=past_event.id,
+                    user_id=creator.id,
+                    invite_status="accepted",
+                    responded_at=datetime.utcnow(),
+                )
+            )
+
+            db.session.commit()
 
 
 from . import routes

--- a/app/database.py
+++ b/app/database.py
@@ -258,3 +258,42 @@ class Invitation(db.Model):
 
     def __repr__(self):
         return f"<Invitation {self.id} from {self.sender_id} to {self.receiver_id} [{self.status}]>"
+
+
+class Event(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    creator_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    title = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.Text, nullable=True)
+    location_or_link = db.Column(db.String(255), nullable=True)
+    visibility_mode = db.Column(db.String(20), nullable=False, default="invite_only")
+    max_attendees = db.Column(db.Integer, nullable=True)
+    start_at = db.Column(db.DateTime, nullable=False)
+    end_at = db.Column(db.DateTime, nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="scheduled")
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    creator = db.relationship("User", backref="created_events", lazy=True)
+    attendees = db.relationship("EventAttendee", backref="event", lazy=True, cascade="all, delete-orphan")
+
+    def __repr__(self):
+        return f"<Event {self.id} {self.title}>"
+
+
+class EventAttendee(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    event_id = db.Column(db.Integer, db.ForeignKey("event.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    invite_status = db.Column(db.String(20), nullable=False, default="invited")
+    responded_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    user = db.relationship("User", backref="event_attendances", lazy=True)
+
+    __table_args__ = (
+        db.UniqueConstraint("event_id", "user_id", name="uq_event_attendee"),
+    )
+
+    def __repr__(self):
+        return f"<EventAttendee event={self.event_id} user={self.user_id} status={self.invite_status}>"

--- a/app/routes.py
+++ b/app/routes.py
@@ -12,6 +12,8 @@ from .database import (
     Conversation,
     ConversationMember,
     DegreeOption,
+    Event,
+    EventAttendee,
     Invitation,
     Message,
     MessageRead,
@@ -33,6 +35,9 @@ DAY_NAMES = [
     "Sunday",
 ]
 TIME_OPTIONS = [f"{hour:02d}:00" for hour in range(6, 24)]
+EVENT_VISIBILITY_MODES = {"invite_only", "open"}
+EVENT_STATUSES = {"scheduled", "cancelled"}
+ATTENDEE_STATUSES = {"invited", "accepted", "declined", "left"}
 
 
 def get_degree_options_by_category():
@@ -175,6 +180,56 @@ def find_matches(user_id, selected_degree_option_id=None):
     return match_results
 
 
+def parse_event_datetime(value):
+    try:
+        return datetime.fromisoformat(value.strip())
+    except (TypeError, ValueError, AttributeError):
+        return None
+
+
+def count_event_accepted_attendees(event):
+    return sum(1 for attendee in event.attendees if attendee.invite_status == "accepted")
+
+
+def is_event_full(event):
+    if event.max_attendees is None:
+        return False
+    return count_event_accepted_attendees(event) >= event.max_attendees
+
+
+def find_event_overlap_for_user(user_id, start_at, end_at, exclude_event_id=None):
+    query = (
+        Event.query.join(EventAttendee, EventAttendee.event_id == Event.id)
+        .filter(Event.status == "scheduled")
+        .filter(EventAttendee.user_id == user_id)
+        .filter(EventAttendee.invite_status == "accepted")
+        .filter(Event.end_at > start_at)
+        .filter(Event.start_at < end_at)
+    )
+
+    if exclude_event_id is not None:
+        query = query.filter(Event.id != exclude_event_id)
+
+    return query.order_by(Event.start_at.asc()).first()
+
+
+def build_event_card_data(event, user_id):
+    attendee_record = next((item for item in event.attendees if item.user_id == user_id), None)
+    attendee_status_counts = {key: 0 for key in ATTENDEE_STATUSES}
+    for attendee in event.attendees:
+        if attendee.invite_status in attendee_status_counts:
+            attendee_status_counts[attendee.invite_status] += 1
+
+    return {
+        "event": event,
+        "attendee_record": attendee_record,
+        "accepted_count": attendee_status_counts["accepted"],
+        "status_counts": attendee_status_counts,
+        "is_full": is_event_full(event),
+        "is_creator": event.creator_user_id == user_id,
+    }
+
+
 @app.route("/")
 def landing():
     return render_template("landing.html")
@@ -238,6 +293,385 @@ def dashboard():
         current_user=user,
         suggested_matches=suggested_matches
     )
+
+
+@app.route("/events")
+@login_required
+def events_page():
+    now = datetime.utcnow()
+
+    my_upcoming_events = (
+        Event.query.join(EventAttendee, EventAttendee.event_id == Event.id)
+        .filter(Event.status == "scheduled")
+        .filter(Event.end_at >= now)
+        .filter(EventAttendee.user_id == current_user.id)
+        .filter(EventAttendee.invite_status == "accepted")
+        .order_by(Event.start_at.asc())
+        .all()
+    )
+
+    invitation_events = (
+        Event.query.join(EventAttendee, EventAttendee.event_id == Event.id)
+        .filter(Event.status == "scheduled")
+        .filter(EventAttendee.user_id == current_user.id)
+        .filter(EventAttendee.invite_status == "invited")
+        .filter(Event.creator_user_id != current_user.id)
+        .order_by(Event.start_at.asc())
+        .all()
+    )
+
+    open_events = (
+        Event.query.filter_by(status="scheduled", visibility_mode="open")
+        .filter(Event.end_at >= now)
+        .filter(Event.creator_user_id != current_user.id)
+        .order_by(Event.start_at.asc())
+        .all()
+    )
+
+    past_events = (
+        Event.query.join(EventAttendee, EventAttendee.event_id == Event.id)
+        .filter(EventAttendee.user_id == current_user.id)
+        .filter(Event.end_at < now)
+        .order_by(Event.start_at.desc())
+        .all()
+    )
+
+    available_invite_users = User.query.filter(User.id != current_user.id).order_by(User.username.asc()).all()
+
+    return render_template(
+        "events.html",
+        current_user=current_user,
+        my_upcoming_events=[build_event_card_data(event, current_user.id) for event in my_upcoming_events],
+        invitation_events=[build_event_card_data(event, current_user.id) for event in invitation_events],
+        open_events=[build_event_card_data(event, current_user.id) for event in open_events],
+        past_events=[build_event_card_data(event, current_user.id) for event in past_events],
+        available_invite_users=available_invite_users,
+        now=now,
+    )
+
+
+@app.route("/events/create", methods=["POST"])
+@login_required
+def create_event():
+    title = request.form.get("title", "").strip()
+    description = request.form.get("description", "").strip()
+    location_or_link = request.form.get("location_or_link", "").strip()
+    visibility_mode = request.form.get("visibility_mode", "invite_only").strip()
+    max_attendees_raw = request.form.get("max_attendees", "").strip()
+    start_at = parse_event_datetime(request.form.get("start_at"))
+    end_at = parse_event_datetime(request.form.get("end_at"))
+
+    if not title or len(title) < 3 or len(title) > 120:
+        flash("Event title must be between 3 and 120 characters.", "error")
+        return redirect(url_for("events_page"))
+
+    if visibility_mode not in EVENT_VISIBILITY_MODES:
+        flash("Invalid event type.", "error")
+        return redirect(url_for("events_page"))
+
+    if start_at is None or end_at is None:
+        flash("Valid start and end times are required.", "error")
+        return redirect(url_for("events_page"))
+
+    if end_at <= start_at:
+        flash("Event end time must be after start time.", "error")
+        return redirect(url_for("events_page"))
+
+    if (end_at - start_at).total_seconds() > 12 * 3600:
+        flash("Event duration cannot exceed 12 hours.", "error")
+        return redirect(url_for("events_page"))
+
+    max_attendees = None
+    if max_attendees_raw:
+        if not max_attendees_raw.isdigit():
+            flash("Max attendees must be a number.", "error")
+            return redirect(url_for("events_page"))
+        max_attendees = int(max_attendees_raw)
+        if max_attendees < 2 or max_attendees > 100:
+            flash("Max attendees must be between 2 and 100.", "error")
+            return redirect(url_for("events_page"))
+
+    if visibility_mode == "open" and max_attendees is None:
+        flash("Open events must include a max attendee limit.", "error")
+        return redirect(url_for("events_page"))
+
+    event = Event(
+        creator_user_id=current_user.id,
+        title=title,
+        description=description or None,
+        location_or_link=location_or_link or None,
+        visibility_mode=visibility_mode,
+        max_attendees=max_attendees,
+        start_at=start_at,
+        end_at=end_at,
+        status="scheduled",
+    )
+    db.session.add(event)
+    db.session.flush()
+
+    db.session.add(
+        EventAttendee(
+            event_id=event.id,
+            user_id=current_user.id,
+            invite_status="accepted",
+            responded_at=datetime.utcnow(),
+        )
+    )
+
+    db.session.commit()
+    flash("Event created successfully.", "success")
+    return redirect(url_for("events_page"))
+
+
+@app.route("/events/<int:event_id>/edit", methods=["POST"])
+@login_required
+def edit_event(event_id):
+    event = Event.query.get_or_404(event_id)
+    if event.creator_user_id != current_user.id:
+        abort(403)
+    if event.status != "scheduled":
+        flash("Only scheduled events can be edited.", "error")
+        return redirect(url_for("events_page"))
+
+    title = request.form.get("title", "").strip()
+    description = request.form.get("description", "").strip()
+    location_or_link = request.form.get("location_or_link", "").strip()
+    visibility_mode = request.form.get("visibility_mode", "invite_only").strip()
+    max_attendees_raw = request.form.get("max_attendees", "").strip()
+    start_at = parse_event_datetime(request.form.get("start_at"))
+    end_at = parse_event_datetime(request.form.get("end_at"))
+
+    if not title or len(title) < 3 or len(title) > 120:
+        flash("Event title must be between 3 and 120 characters.", "error")
+        return redirect(url_for("events_page"))
+    if visibility_mode not in EVENT_VISIBILITY_MODES:
+        flash("Invalid event type.", "error")
+        return redirect(url_for("events_page"))
+    if start_at is None or end_at is None:
+        flash("Valid start and end times are required.", "error")
+        return redirect(url_for("events_page"))
+    if end_at <= start_at:
+        flash("Event end time must be after start time.", "error")
+        return redirect(url_for("events_page"))
+
+    max_attendees = None
+    if max_attendees_raw:
+        if not max_attendees_raw.isdigit():
+            flash("Max attendees must be a number.", "error")
+            return redirect(url_for("events_page"))
+        max_attendees = int(max_attendees_raw)
+        if max_attendees < 2 or max_attendees > 100:
+            flash("Max attendees must be between 2 and 100.", "error")
+            return redirect(url_for("events_page"))
+
+    if visibility_mode == "open" and max_attendees is None:
+        flash("Open events must include a max attendee limit.", "error")
+        return redirect(url_for("events_page"))
+
+    accepted_count = count_event_accepted_attendees(event)
+    if max_attendees is not None and accepted_count > max_attendees:
+        flash("Max attendees cannot be below current accepted attendee count.", "error")
+        return redirect(url_for("events_page"))
+
+    event.title = title
+    event.description = description or None
+    event.location_or_link = location_or_link or None
+    event.visibility_mode = visibility_mode
+    event.max_attendees = max_attendees
+    event.start_at = start_at
+    event.end_at = end_at
+
+    accepted_attendees = [item for item in event.attendees if item.user_id != current_user.id and item.invite_status == "accepted"]
+    for attendee in accepted_attendees:
+        db.session.add(
+            Notification(
+                user_id=attendee.user_id,
+                sender_name=current_user.username,
+                type="mention",
+                message=f"Event updated: <strong>{event.title}</strong> now starts at {event.start_at.strftime('%Y-%m-%d %H:%M')}.",
+                channel="Events",
+            )
+        )
+
+    db.session.commit()
+    flash("Event updated.", "success")
+    return redirect(url_for("events_page"))
+
+
+@app.route("/events/<int:event_id>/cancel", methods=["POST"])
+@login_required
+def cancel_event(event_id):
+    event = Event.query.get_or_404(event_id)
+    if event.creator_user_id != current_user.id:
+        abort(403)
+    if event.status != "scheduled":
+        flash("Event is already cancelled.", "info")
+        return redirect(url_for("events_page"))
+
+    event.status = "cancelled"
+
+    for attendee in event.attendees:
+        if attendee.user_id == current_user.id or attendee.invite_status == "declined":
+            continue
+        db.session.add(
+            Notification(
+                user_id=attendee.user_id,
+                sender_name=current_user.username,
+                type="mention",
+                message=f"Event cancelled: <strong>{event.title}</strong>.",
+                channel="Events",
+            )
+        )
+
+    db.session.commit()
+    flash("Event cancelled.", "success")
+    return redirect(url_for("events_page"))
+
+
+@app.route("/events/<int:event_id>/invite", methods=["POST"])
+@login_required
+def invite_to_event(event_id):
+    event = Event.query.get_or_404(event_id)
+    if event.creator_user_id != current_user.id:
+        abort(403)
+    if event.status != "scheduled":
+        flash("Cannot invite attendees to a cancelled event.", "error")
+        return redirect(url_for("events_page"))
+
+    identifiers = request.form.get("invite_identifiers", "")
+    raw_items = [item.strip() for item in identifiers.split(",") if item.strip()]
+    if not raw_items:
+        flash("Enter at least one username or email to invite.", "error")
+        return redirect(url_for("events_page"))
+
+    if len(raw_items) > 20:
+        flash("You can invite up to 20 users per event at a time.", "error")
+        return redirect(url_for("events_page"))
+
+    invited_count = 0
+    skipped_count = 0
+
+    for identifier in raw_items:
+        user = User.query.filter(or_(User.username == identifier, User.email == identifier)).first()
+        if user is None or user.id == current_user.id:
+            skipped_count += 1
+            continue
+
+        existing = EventAttendee.query.filter_by(event_id=event.id, user_id=user.id).first()
+        if existing is not None:
+            skipped_count += 1
+            continue
+
+        db.session.add(EventAttendee(event_id=event.id, user_id=user.id, invite_status="invited"))
+        db.session.add(
+            Notification(
+                user_id=user.id,
+                sender_name=current_user.username,
+                type="mention",
+                message=f"You were invited to <strong>{event.title}</strong>.",
+                channel="Events",
+            )
+        )
+        invited_count += 1
+
+    db.session.commit()
+
+    if invited_count:
+        flash(f"Sent {invited_count} event invite(s).", "success")
+    if skipped_count:
+        flash(f"Skipped {skipped_count} user(s) (not found, self, or already invited).", "info")
+    return redirect(url_for("events_page"))
+
+
+@app.route("/events/<int:event_id>/join", methods=["POST"])
+@login_required
+def join_open_event(event_id):
+    event = Event.query.get_or_404(event_id)
+    if event.status != "scheduled" or event.visibility_mode != "open":
+        flash("This event is not open for joining.", "error")
+        return redirect(url_for("events_page"))
+
+    attendee = EventAttendee.query.filter_by(event_id=event.id, user_id=current_user.id).first()
+    if attendee and attendee.invite_status == "accepted":
+        flash("You already joined this event.", "info")
+        return redirect(url_for("events_page"))
+
+    if is_event_full(event):
+        flash("Event is full.", "error")
+        return redirect(url_for("events_page"))
+
+    if attendee is None:
+        attendee = EventAttendee(event_id=event.id, user_id=current_user.id)
+        db.session.add(attendee)
+
+    attendee.invite_status = "accepted"
+    attendee.responded_at = datetime.utcnow()
+    db.session.commit()
+    flash("You joined the event.", "success")
+    return redirect(url_for("events_page"))
+
+
+@app.route("/events/<int:event_id>/respond", methods=["POST"])
+@login_required
+def respond_to_event_invite(event_id):
+    event = Event.query.get_or_404(event_id)
+    action = request.form.get("action", "").strip()
+    confirm_conflict = request.form.get("confirm_conflict") == "1"
+
+    attendee = EventAttendee.query.filter_by(event_id=event.id, user_id=current_user.id).first()
+    if attendee is None:
+        abort(403)
+
+    if action not in {"accept", "decline"}:
+        flash("Invalid invite response.", "error")
+        return redirect(url_for("events_page"))
+
+    if event.status != "scheduled":
+        flash("This event is no longer active.", "error")
+        return redirect(url_for("events_page"))
+
+    if action == "decline":
+        attendee.invite_status = "declined"
+        attendee.responded_at = datetime.utcnow()
+        db.session.commit()
+        flash("Invitation declined.", "info")
+        return redirect(url_for("events_page"))
+
+    overlap = find_event_overlap_for_user(current_user.id, event.start_at, event.end_at, exclude_event_id=event.id)
+    if overlap is not None and not confirm_conflict:
+        flash(
+            f"Schedule conflict with '{overlap.title}'. Click accept again to confirm.",
+            "error",
+        )
+        return redirect(url_for("events_page"))
+
+    if is_event_full(event) and attendee.invite_status != "accepted":
+        flash("Event is full.", "error")
+        return redirect(url_for("events_page"))
+
+    attendee.invite_status = "accepted"
+    attendee.responded_at = datetime.utcnow()
+    db.session.commit()
+    flash("Invitation accepted.", "success")
+    return redirect(url_for("events_page"))
+
+
+@app.route("/events/<int:event_id>/leave", methods=["POST"])
+@login_required
+def leave_event(event_id):
+    event = Event.query.get_or_404(event_id)
+    attendee = EventAttendee.query.filter_by(event_id=event.id, user_id=current_user.id).first()
+    if attendee is None:
+        abort(403)
+    if event.creator_user_id == current_user.id:
+        flash("Event creators cannot leave their own event. Cancel it instead.", "error")
+        return redirect(url_for("events_page"))
+
+    attendee.invite_status = "left"
+    attendee.responded_at = datetime.utcnow()
+    db.session.commit()
+    flash("You left the event.", "info")
+    return redirect(url_for("events_page"))
 
 
 @app.route("/matches")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -31,6 +31,9 @@
                 <a href="{{ url_for('matches', user_id=current_user.id if current_user else 1) }}" class="{% if request.endpoint == 'matches' %}active{% endif %}">
                     <i class="bi bi-people"></i> Matches
                 </a>
+                <a href="{{ url_for('events_page') }}" class="{% if request.endpoint == 'events_page' %}active{% endif %}">
+                    <i class="bi bi-calendar-event"></i> Events
+                </a>
                 <a href="{{ url_for('notifications') }}"
                     class="{% if request.endpoint == 'notifications' %}active{% endif %}">
                     <i class="bi bi-bell"></i> Notifications

--- a/app/templates/events.html
+++ b/app/templates/events.html
@@ -1,0 +1,310 @@
+{% extends "base.html" %}
+{% block title %}Events{% endblock %}
+
+{% block head %}
+<style>
+    .sidebar .sidebar-section:nth-of-type(2) {
+        display: none !important;
+    }
+
+    .sidebar a#editProfileBtn {
+        display: none;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="page-header d-flex justify-content-between align-items-center">
+    <div>
+        <h1>Events</h1>
+        <p>Create and manage study meetings.</p>
+    </div>
+    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createEventModal">
+        <i class="bi bi-calendar-plus"></i> Create Event
+    </button>
+</div>
+
+<section class="info-card mb-4">
+    <h4 class="mb-3">Upcoming Events</h4>
+    {% if my_upcoming_events %}
+        <div class="row g-3">
+            {% for item in my_upcoming_events %}
+                {% set event = item.event %}
+                <div class="col-md-6">
+                    <div class="border rounded p-3 h-100" style="border-color: rgba(255,255,255,0.08) !important;">
+                        <div class="d-flex justify-content-between align-items-start mb-2">
+                            <h5 class="mb-0">{{ event.title }}</h5>
+                            <span class="badge text-bg-secondary">{{ event.visibility_mode.replace('_', ' ')|title }}</span>
+                        </div>
+                        <p class="mb-1"><strong>Time:</strong> {{ event.start_at.strftime("%Y-%m-%d %H:%M") }} - {{ event.end_at.strftime("%H:%M") }}</p>
+                        <p class="mb-1"><strong>Role:</strong> {% if item.is_creator %}Creator{% else %}Attendee{% endif %}</p>
+                        <p class="mb-1"><strong>Location:</strong> {{ event.location_or_link or "Not set" }}</p>
+                        <p class="mb-2"><strong>Attendees:</strong> {{ item.accepted_count }}{% if event.max_attendees %}/{{ event.max_attendees }}{% endif %}</p>
+                        <p class="mb-2 text-light" style="opacity:0.8;">{{ event.description or "No description." }}</p>
+
+                        <div class="mb-2">
+                            <small class="text-light" style="opacity:0.85;">Accepted {{ item.status_counts.accepted }} • Invited {{ item.status_counts.invited }} • Declined {{ item.status_counts.declined }} • Left {{ item.status_counts.left }}</small>
+                        </div>
+
+                        {% if item.is_creator %}
+                            <div class="d-flex flex-wrap gap-2">
+                                <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#editEventModal{{ event.id }}">Edit</button>
+                                <button class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#inviteEventModal{{ event.id }}">Invite</button>
+                                <form method="POST" action="{{ url_for('cancel_event', event_id=event.id) }}">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">Cancel</button>
+                                </form>
+                            </div>
+                        {% else %}
+                            <form method="POST" action="{{ url_for('leave_event', event_id=event.id) }}">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-sm btn-outline-warning">Leave</button>
+                            </form>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <p class="mb-0 text-light">No upcoming events yet.</p>
+    {% endif %}
+</section>
+
+<section class="info-card mb-4">
+    <h4 class="mb-3">Pending Invites</h4>
+    {% if invitation_events %}
+        <div class="row g-3">
+            {% for item in invitation_events %}
+                {% set event = item.event %}
+                <div class="col-md-6">
+                    <div class="border rounded p-3 h-100" style="border-color: rgba(255,255,255,0.08) !important;">
+                        <h5 class="mb-1">{{ event.title }}</h5>
+                        <p class="mb-1"><strong>Host:</strong> {{ event.creator.username }}</p>
+                        <p class="mb-1"><strong>Time:</strong> {{ event.start_at.strftime("%Y-%m-%d %H:%M") }} - {{ event.end_at.strftime("%H:%M") }}</p>
+                        <p class="mb-2"><strong>Location:</strong> {{ event.location_or_link or "Not set" }}</p>
+                        <p class="mb-2 text-light" style="opacity:0.8;">{{ event.description or "No description." }}</p>
+
+                        {% if item.attendee_record and item.attendee_record.invite_status == "accepted" %}
+                            <form method="POST" action="{{ url_for('leave_event', event_id=event.id) }}" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-sm btn-outline-warning">Leave</button>
+                            </form>
+                        {% else %}
+                            <form method="POST" action="{{ url_for('respond_to_event_invite', event_id=event.id) }}" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <input type="hidden" name="action" value="accept">
+                                <button type="submit" class="btn btn-sm btn-success">Accept</button>
+                            </form>
+                            <form method="POST" action="{{ url_for('respond_to_event_invite', event_id=event.id) }}" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <input type="hidden" name="action" value="accept">
+                                <input type="hidden" name="confirm_conflict" value="1">
+                                <button type="submit" class="btn btn-sm btn-outline-success">Accept (confirm conflict)</button>
+                            </form>
+                            <form method="POST" action="{{ url_for('respond_to_event_invite', event_id=event.id) }}" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <input type="hidden" name="action" value="decline">
+                                <button type="submit" class="btn btn-sm btn-outline-danger">Decline</button>
+                            </form>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <p class="mb-0 text-light">No pending event invitations.</p>
+    {% endif %}
+</section>
+
+<section class="info-card mb-4">
+    <h4 class="mb-3">Open Events</h4>
+    {% if open_events %}
+        <div class="row g-3">
+            {% for item in open_events %}
+                {% set event = item.event %}
+                <div class="col-md-6">
+                    <div class="border rounded p-3 h-100" style="border-color: rgba(255,255,255,0.08) !important;">
+                        <h5 class="mb-1">{{ event.title }}</h5>
+                        <p class="mb-1"><strong>Host:</strong> {{ event.creator.username }}</p>
+                        <p class="mb-1"><strong>Time:</strong> {{ event.start_at.strftime("%Y-%m-%d %H:%M") }} - {{ event.end_at.strftime("%H:%M") }}</p>
+                        <p class="mb-2"><strong>Capacity:</strong> {{ item.accepted_count }}{% if event.max_attendees %}/{{ event.max_attendees }}{% endif %}</p>
+                        <p class="mb-2 text-light" style="opacity:0.8;">{{ event.description or "No description." }}</p>
+
+                        {% if item.attendee_record and item.attendee_record.invite_status == "accepted" %}
+                            <form method="POST" action="{{ url_for('leave_event', event_id=event.id) }}">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-sm btn-outline-warning">Leave</button>
+                            </form>
+                        {% elif item.is_full %}
+                            <button class="btn btn-sm btn-secondary" disabled>Event Full</button>
+                        {% else %}
+                            <form method="POST" action="{{ url_for('join_open_event', event_id=event.id) }}">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-sm btn-primary">Join Event</button>
+                            </form>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <p class="mb-0 text-light">No open events available right now.</p>
+    {% endif %}
+</section>
+
+<section class="info-card">
+    <h4 class="mb-3">Past Events</h4>
+    {% if past_events %}
+        <ul class="list-unstyled mb-0">
+            {% for item in past_events %}
+                <li class="mb-2">
+                    <strong>{{ item.event.title }}</strong>
+                    <span class="text-light" style="opacity:0.8;">({{ item.event.start_at.strftime("%Y-%m-%d %H:%M") }})</span>
+                </li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p class="mb-0 text-light">No past events yet.</p>
+    {% endif %}
+</section>
+{% endblock %}
+
+{% block modals %}
+<div class="modal fade" id="createEventModal" tabindex="-1">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Create Event</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form method="POST" action="{{ url_for('create_event') }}">
+                <div class="modal-body">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-3">
+                        <label class="form-label">Title</label>
+                        <input type="text" class="form-control" name="title" required minlength="3" maxlength="120">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Description</label>
+                        <textarea class="form-control" name="description" rows="3"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Location or Link</label>
+                        <input type="text" class="form-control" name="location_or_link" maxlength="255">
+                    </div>
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-6">
+                            <label class="form-label">Start</label>
+                            <input type="datetime-local" class="form-control" name="start_at" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">End</label>
+                            <input type="datetime-local" class="form-control" name="end_at" required>
+                        </div>
+                    </div>
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label">Event Type</label>
+                            <select class="form-select" name="visibility_mode" required>
+                                <option value="invite_only">Invite Only</option>
+                                <option value="open">Open</option>
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Max Attendees (required for open)</label>
+                            <input type="number" class="form-control" name="max_attendees" min="2" max="100">
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Create</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+{% for item in my_upcoming_events %}
+    {% if item.is_creator %}
+        {% set event = item.event %}
+        <div class="modal fade" id="editEventModal{{ event.id }}" tabindex="-1">
+            <div class="modal-dialog modal-lg modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Edit Event</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <form method="POST" action="{{ url_for('edit_event', event_id=event.id) }}">
+                        <div class="modal-body">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <div class="mb-3">
+                                <label class="form-label">Title</label>
+                                <input type="text" class="form-control" name="title" value="{{ event.title }}" required minlength="3" maxlength="120">
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Description</label>
+                                <textarea class="form-control" name="description" rows="3">{{ event.description or '' }}</textarea>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Location or Link</label>
+                                <input type="text" class="form-control" name="location_or_link" value="{{ event.location_or_link or '' }}" maxlength="255">
+                            </div>
+                            <div class="row g-3 mb-3">
+                                <div class="col-md-6">
+                                    <label class="form-label">Start</label>
+                                    <input type="datetime-local" class="form-control" name="start_at" value="{{ event.start_at.strftime('%Y-%m-%dT%H:%M') }}" required>
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">End</label>
+                                    <input type="datetime-local" class="form-control" name="end_at" value="{{ event.end_at.strftime('%Y-%m-%dT%H:%M') }}" required>
+                                </div>
+                            </div>
+                            <div class="row g-3">
+                                <div class="col-md-6">
+                                    <label class="form-label">Event Type</label>
+                                    <select class="form-select" name="visibility_mode" required>
+                                        <option value="invite_only" {% if event.visibility_mode == 'invite_only' %}selected{% endif %}>Invite Only</option>
+                                        <option value="open" {% if event.visibility_mode == 'open' %}selected{% endif %}>Open</option>
+                                    </select>
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">Max Attendees</label>
+                                    <input type="number" class="form-control" name="max_attendees" min="2" max="100" value="{{ event.max_attendees if event.max_attendees else '' }}">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                            <button type="submit" class="btn btn-primary">Save</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <div class="modal fade" id="inviteEventModal{{ event.id }}" tabindex="-1">
+            <div class="modal-dialog modal-lg modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Invite Users to {{ event.title }}</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <form method="POST" action="{{ url_for('invite_to_event', event_id=event.id) }}">
+                        <div class="modal-body">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <label class="form-label">Enter usernames or emails (comma separated)</label>
+                            <input type="text" class="form-control mb-3" name="invite_identifiers" placeholder="alice1, ben1, user@example.com" required>
+                            <small class="text-light" style="opacity:0.8;">You can send up to 20 invites per submission.</small>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                            <button type="submit" class="btn btn-primary">Send Invites</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endfor %}
+{% endblock %}

--- a/migrations/versions/ab12cd34ef56_add_events_tables.py
+++ b/migrations/versions/ab12cd34ef56_add_events_tables.py
@@ -1,0 +1,70 @@
+"""add events tables
+
+Revision ID: ab12cd34ef56
+Revises: c3e7a9f4d2b1
+Create Date: 2026-05-08 12:30:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ab12cd34ef56"
+down_revision = "c3e7a9f4d2b1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "event",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("creator_user_id", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(length=120), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("location_or_link", sa.String(length=255), nullable=True),
+        sa.Column("visibility_mode", sa.String(length=20), nullable=False),
+        sa.Column("max_attendees", sa.Integer(), nullable=True),
+        sa.Column("start_at", sa.DateTime(), nullable=False),
+        sa.Column("end_at", sa.DateTime(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["creator_user_id"], ["user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint("visibility_mode in ('invite_only', 'open')", name="ck_event_visibility_mode"),
+        sa.CheckConstraint("status in ('scheduled', 'cancelled')", name="ck_event_status"),
+        sa.CheckConstraint("max_attendees IS NULL OR max_attendees >= 2", name="ck_event_max_attendees"),
+        sa.CheckConstraint("end_at > start_at", name="ck_event_time_window"),
+    )
+    op.create_index("ix_event_creator_user_id", "event", ["creator_user_id"], unique=False)
+    op.create_index("ix_event_status_start_at", "event", ["status", "start_at"], unique=False)
+
+    op.create_table(
+        "event_attendee",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("invite_status", sa.String(length=20), nullable=False),
+        sa.Column("responded_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["event_id"], ["event.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("event_id", "user_id", name="uq_event_attendee"),
+        sa.CheckConstraint(
+            "invite_status in ('invited', 'accepted', 'declined', 'left')",
+            name="ck_event_attendee_status",
+        ),
+    )
+    op.create_index("ix_event_attendee_user_id", "event_attendee", ["user_id"], unique=False)
+
+
+def downgrade():
+    op.drop_index("ix_event_attendee_user_id", table_name="event_attendee")
+    op.drop_table("event_attendee")
+
+    op.drop_index("ix_event_status_start_at", table_name="event")
+    op.drop_index("ix_event_creator_user_id", table_name="event")
+    op.drop_table("event")


### PR DESCRIPTION
## Summary
- add phase-1 events backend and UI with a new `/events` page, creator/invitee actions, and sidebar navigation entry
- implement event data model + migration (`event` and `event_attendee`) including visibility modes, attendee statuses, capacity checks, and schedule constraints
- add invite/respond/join/leave/cancel flows with CSRF-protected forms, attendee notifications, and idempotent demo event seeding at startup