### PR TITLE
Improve matching logic, registration validation feedback and profile page ordering

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -267,6 +267,7 @@ def build_overlap_summary(requester_availability, candidate_availability):
     return overlap_minutes_total, overlap_by_day
 
 
+
 def normalise_text(value):
     if not value:
         return ""
@@ -289,35 +290,41 @@ def calculate_academic_score(requester, candidate):
     candidate_second_major = normalise_text(candidate.second_major)
     candidate_minor = normalise_text(candidate.minor)
 
-    requester_secondary_fields = {
+    requester_major_fields = {
+        requester_major,
         requester_second_major,
-        requester_minor,
     } - {""}
 
-    candidate_secondary_fields = {
+    candidate_major_fields = {
+        candidate_major,
         candidate_second_major,
-        candidate_minor,
     } - {""}
 
-    if requester_major and requester_major == candidate_major:
-        score += 70
-        matched_fields.append("Same major")
+    shared_major_fields = requester_major_fields.intersection(candidate_major_fields)
 
-    if requester_second_major and requester_second_major == candidate_second_major:
-        score += 45
-        matched_fields.append("Same second major")
+    for shared_field in shared_major_fields:
+        score += 70
+
+        if requester_major == candidate_major == shared_field:
+            matched_fields.append("Same major")
+
+        elif requester_second_major == candidate_second_major == shared_field:
+            matched_fields.append("Same second major")
+
+        else:
+            matched_fields.append("Major/second major match")
 
     if requester_minor and requester_minor == candidate_minor:
         score += 25
         matched_fields.append("Same minor")
 
-    if requester_major and requester_major in candidate_secondary_fields:
-        score += 45
-        matched_fields.append("Your major matches their second major/minor")
+    if requester_minor and requester_minor in candidate_major_fields:
+        score += 25
+        matched_fields.append("Your minor matches their major/second major")
 
-    if candidate_major and candidate_major in requester_secondary_fields:
-        score += 45
-        matched_fields.append("Their major matches your second major/minor")
+    if candidate_minor and candidate_minor in requester_major_fields:
+        score += 25
+        matched_fields.append("Their minor matches your major/second major")
 
     same_degree = (
         requester.degree_option_id is not None
@@ -334,146 +341,6 @@ def calculate_academic_score(requester, candidate):
 
     return score, matched_fields, same_degree
 
-
-def calculate_availability_score(overlap_by_day):
-    valid_overlap_days = 0
-    useful_overlap_days = 0
-    strong_overlap_days = 0
-    overlap_minutes_total = 0
-    strongest_single_day_overlap = 0
-
-    for overlaps in overlap_by_day.values():
-        day_total = 0
-
-        for start_time, end_time in overlaps:
-            day_total += (
-                time_to_minutes(end_time)
-                - time_to_minutes(start_time)
-            )
-
-        overlap_minutes_total += day_total
-
-        if day_total >= 30:
-            valid_overlap_days += 1
-
-        if day_total >= 45:
-            useful_overlap_days += 1
-
-        if day_total >= 90:
-            strong_overlap_days += 1
-
-        strongest_single_day_overlap = max(
-            strongest_single_day_overlap,
-            day_total
-        )
-
-    if valid_overlap_days == 0:
-        return None
-
-    availability_score = (
-        valid_overlap_days * 30
-        + useful_overlap_days * 45
-        + strong_overlap_days * 60
-        + (overlap_minutes_total / 60) * 40
-        + (strongest_single_day_overlap / 60) * 20
-    )
-
-    return {
-        "availability_score": availability_score,
-        "valid_overlap_days": valid_overlap_days,
-        "useful_overlap_days": useful_overlap_days,
-        "strong_overlap_days": strong_overlap_days,
-        "overlap_minutes_total": overlap_minutes_total,
-        "strongest_single_day_overlap": strongest_single_day_overlap,
-    }
-
-
-def normalise_text(value):
-    if not value:
-        return ""
-    return value.strip().lower()
-
-
-def get_shared_unit_score(shared_unit_count):
-    # Strong academic weighting without becoming overwhelming.
-    return shared_unit_count * 100
-
-
-def calculate_academic_score(requester, candidate):
-    score = 0
-    matched_fields = []
-
-    requester_major = normalise_text(requester.major)
-    requester_second_major = normalise_text(requester.second_major)
-    requester_minor = normalise_text(requester.minor)
-
-    candidate_major = normalise_text(candidate.major)
-    candidate_second_major = normalise_text(candidate.second_major)
-    candidate_minor = normalise_text(candidate.minor)
-
-    requester_secondary_fields = {
-        requester_second_major,
-        requester_minor,
-    } - {""}
-
-    candidate_secondary_fields = {
-        candidate_second_major,
-        candidate_minor,
-    } - {""}
-
-    # Same primary major
-    if requester_major and requester_major == candidate_major:
-        score += 70
-        matched_fields.append("Same major")
-
-    # Same second major
-    if (
-        requester_second_major
-        and requester_second_major == candidate_second_major
-    ):
-        score += 45
-        matched_fields.append("Same second major")
-
-    # Same minor
-    if requester_minor and requester_minor == candidate_minor:
-        score += 25
-        matched_fields.append("Same minor")
-
-    # Cross-field matches
-    if (
-        requester_major
-        and requester_major in candidate_secondary_fields
-    ):
-        score += 45
-        matched_fields.append(
-            "Your major matches their second major/minor"
-        )
-
-    if (
-        candidate_major
-        and candidate_major in requester_secondary_fields
-    ):
-        score += 45
-        matched_fields.append(
-            "Their major matches your second major/minor"
-        )
-
-    # Same degree
-    same_degree = (
-        requester.degree_option_id is not None
-        and candidate.degree_option_id == requester.degree_option_id
-    ) or (
-        requester.degree
-        and candidate.degree
-        and requester.degree.strip().lower()
-        == candidate.degree.strip().lower()
-    )
-
-    if same_degree:
-        score += 20
-        matched_fields.append("Same degree")
-
-    return score, matched_fields, same_degree
 
 
 def calculate_availability_score(overlap_by_day):

--- a/app/templates/loginpage.html
+++ b/app/templates/loginpage.html
@@ -161,7 +161,7 @@
                     return false;
                 }
 
-                loginMessage.textContent = "Email looks good.";
+                loginMessage.textContent = "Email format looks valid.";
                 return true;
             }
 

--- a/app/templates/reset_password.html
+++ b/app/templates/reset_password.html
@@ -4,32 +4,237 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Reset Password | StudySync</title>
+
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 
 <body>
+
     <section class="reset-password-page">
+
         <div class="reset-card">
+
             <h1>Reset Your Password</h1>
-            <p>Enter your new password below to secure your StudySync account.</p>
+
+            <p>
+                Enter your new password below to secure your StudySync account.
+            </p>
 
             <form method="POST" class="reset-form">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
-                <label for="password">New Password</label>
-                <input type="password" id="password" name="password" placeholder="Enter new password" required>
+                <input
+                    type="hidden"
+                    name="csrf_token"
+                    value="{{ csrf_token() }}"
+                >
 
-                <label for="confirm_password">Confirm Password</label>
-                <input type="password" id="confirm_password" name="confirm_password" placeholder="Confirm new password" required>
+                <label for="password">
+                    New Password
+                </label>
 
-                <button type="submit">Reset Password</button>
+                <input
+                    type="password"
+                    id="password"
+                    name="password"
+                    placeholder="Enter new password"
+                    required
+                >
+
+                <small
+                    class="input-message"
+                    id="password-message"
+                ></small>
+
+
+                <label for="confirm_password">
+                    Confirm Password
+                </label>
+
+                <input
+                    type="password"
+                    id="confirm_password"
+                    name="confirm_password"
+                    placeholder="Confirm new password"
+                    required
+                >
+
+                <small
+                    class="input-message"
+                    id="confirm-password-message"
+                ></small>
+
+                <button type="submit">
+                    Reset Password
+                </button>
+
             </form>
 
-            <a href="{{ url_for('login') }}" class="reset-back-link">← Back to Login</a>
+            <a
+                href="{{ url_for('login') }}"
+                class="reset-back-link"
+            >
+                ← Back to Login
+            </a>
+
         </div>
+
     </section>
+
+    <script>
+
+        const resetForm =
+            document.querySelector(".reset-form");
+
+        const passwordInput =
+            document.getElementById("password");
+
+        const confirmPasswordInput =
+            document.getElementById("confirm_password");
+
+        const passwordMessage =
+            document.getElementById("password-message");
+
+        const confirmPasswordMessage =
+            document.getElementById("confirm-password-message");
+
+        let passwordIsValid = false;
+        let passwordsMatch = false;
+
+        function setMessage(element, message, type) {
+
+            element.textContent = message;
+
+            element.classList.remove(
+                "valid-message",
+                "error-message"
+            );
+
+            if (type === "valid") {
+                element.classList.add("valid-message");
+            }
+
+            if (type === "error") {
+                element.classList.add("error-message");
+            }
+        }
+
+        function checkPassword() {
+
+            const password =
+                passwordInput.value;
+
+            passwordIsValid = false;
+
+            if (!password) {
+
+                setMessage(
+                    passwordMessage,
+                    "",
+                    ""
+                );
+
+                return;
+            }
+
+            if (password.length < 6) {
+
+                setMessage(
+                    passwordMessage,
+                    "Password must be at least 6 characters.",
+                    "error"
+                );
+
+                return;
+            }
+
+            passwordIsValid = true;
+
+            setMessage(
+                passwordMessage,
+                "Password format looks valid.",
+                "valid"
+            );
+        }
+
+        function checkConfirmPassword() {
+
+            const password =
+                passwordInput.value;
+
+            const confirmPassword =
+                confirmPasswordInput.value;
+
+            passwordsMatch = false;
+
+            if (!confirmPassword) {
+
+                setMessage(
+                    confirmPasswordMessage,
+                    "",
+                    ""
+                );
+
+                return;
+            }
+
+            if (password !== confirmPassword) {
+
+                setMessage(
+                    confirmPasswordMessage,
+                    "Passwords do not match.",
+                    "error"
+                );
+
+                return;
+            }
+
+            passwordsMatch = true;
+
+            setMessage(
+                confirmPasswordMessage,
+                "Passwords match.",
+                "valid"
+            );
+        }
+
+        passwordInput.addEventListener(
+            "input",
+            function() {
+
+                checkPassword();
+                checkConfirmPassword();
+            }
+        );
+
+        confirmPasswordInput.addEventListener(
+            "input",
+            function() {
+
+                checkConfirmPassword();
+            }
+        );
+
+        resetForm.addEventListener(
+            "submit",
+            function(event) {
+
+                checkPassword();
+                checkConfirmPassword();
+
+                if (
+                    !passwordIsValid ||
+                    !passwordsMatch
+                ) {
+                    event.preventDefault();
+                }
+            }
+        );
+
+    </script>
+
 </body>
 </html>
+
 
 
 

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -391,9 +391,205 @@
             }
         }
 
+        const form = document.getElementById("register-form");
+
+        const emailInput = document.getElementById("email");
+        const usernameInput = document.getElementById("username");
+        const passwordInput = document.getElementById("password");
+        const confirmPasswordInput = document.getElementById("confirm-password");
+
+        const emailMessage = document.getElementById("email-message");
+        const usernameMessage = document.getElementById("username-message");
+        const passwordMessage = document.getElementById("password-message");
+        const confirmPasswordMessage = document.getElementById("confirm-password-message");
+        const formError = document.getElementById("form-error");
+
+        let emailIsValid = false;
+        let usernameIsValid = false;
+        let passwordIsValid = false;
+        let passwordsMatch = false;
+
+        function setMessage(element, message, type) {
+            element.textContent = message;
+            element.classList.remove("valid-message", "error-message");
+
+            if (type === "valid") {
+                element.classList.add("valid-message");
+            }
+
+            if (type === "error") {
+                element.classList.add("error-message");
+            }
+        }
+
+        function isEmailFormatValid(email) {
+            return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(email);
+        }
+
+        async function checkEmail() {
+            const email = emailInput.value.trim();
+
+            emailIsValid = false;
+
+            if (!email) {
+                setMessage(emailMessage, "", "");
+                return;
+            }
+
+            if (!isEmailFormatValid(email)) {
+                setMessage(emailMessage, "Enter a valid email format.", "error");
+                return;
+            }
+
+            try {
+                const response = await fetch(
+                    `/check_register_details?email=${encodeURIComponent(email)}`
+                );
+
+                const data = await response.json();
+
+                if (data.email_exists) {
+                    setMessage(emailMessage, "This email is already registered.", "error");
+                    return;
+                }
+
+                emailIsValid = true;
+                setMessage(emailMessage, "Email format looks valid.", "valid");
+
+            } catch (error) {
+                setMessage(emailMessage, "Could not check email right now.", "error");
+            }
+        }
+
+        async function checkUsername() {
+            const username = usernameInput.value.trim();
+
+            usernameIsValid = false;
+
+            if (!username) {
+                setMessage(usernameMessage, "", "");
+                return;
+            }
+
+            if (username.length < 5) {
+                setMessage(usernameMessage, "Username must be at least 5 characters.", "error");
+                return;
+            }
+
+            if (username.includes("@")) {
+                setMessage(usernameMessage, "Username cannot contain @.", "error");
+                return;
+            }
+
+            try {
+                const response = await fetch(
+                    `/check_register_details?username=${encodeURIComponent(username)}`
+                );
+
+                const data = await response.json();
+
+                if (data.username_exists) {
+                    setMessage(usernameMessage, "This username is already taken.", "error");
+                    return;
+                }
+
+                usernameIsValid = true;
+                setMessage(usernameMessage, "Username is available.", "valid");
+
+            } catch (error) {
+                setMessage(usernameMessage, "Could not check username right now.", "error");
+            }
+        }
+
+        function checkPassword() {
+            const password = passwordInput.value;
+
+            passwordIsValid = false;
+
+            if (!password) {
+                setMessage(passwordMessage, "", "");
+                return;
+            }
+
+            if (password.length < 6) {
+                setMessage(passwordMessage, "Password must be at least 6 characters.", "error");
+                return;
+            }
+
+            passwordIsValid = true;
+            setMessage(passwordMessage, "Password length looks valid.", "valid");
+        }
+
+        function checkConfirmPassword() {
+            const password = passwordInput.value;
+            const confirmPassword = confirmPasswordInput.value;
+
+            passwordsMatch = false;
+
+            if (!confirmPassword) {
+                setMessage(confirmPasswordMessage, "", "");
+                return;
+            }
+
+            if (password !== confirmPassword) {
+                setMessage(confirmPasswordMessage, "Passwords do not match.", "error");
+                return;
+            }
+
+            passwordsMatch = true;
+            setMessage(confirmPasswordMessage, "Passwords match.", "valid");
+        }
+
+        let emailTimer;
+        let usernameTimer;
+
+        emailInput.addEventListener("input", function() {
+            clearTimeout(emailTimer);
+
+            emailTimer = setTimeout(function() {
+                checkEmail();
+            }, 400);
+        });
+
+        usernameInput.addEventListener("input", function() {
+            clearTimeout(usernameTimer);
+
+            usernameTimer = setTimeout(function() {
+                checkUsername();
+            }, 400);
+        });
+
+        passwordInput.addEventListener("input", function() {
+            checkPassword();
+            checkConfirmPassword();
+        });
+
+        confirmPasswordInput.addEventListener("input", function() {
+            checkConfirmPassword();
+        });
+
+        form.addEventListener("submit", async function(event) {
+            formError.textContent = "";
+
+            await checkEmail();
+            await checkUsername();
+            checkPassword();
+            checkConfirmPassword();
+
+            if (
+                !emailIsValid ||
+                !usernameIsValid ||
+                !passwordIsValid ||
+                !passwordsMatch
+            ) {
+                event.preventDefault();
+                formError.textContent =
+                    "Please fix the highlighted registration details before continuing.";
+            }
+        });
+
     </script>
 
 </body>
 </html>
-
 

--- a/app/templates/userpages.html
+++ b/app/templates/userpages.html
@@ -50,131 +50,132 @@
 
 <div class="row g-4">
 
-    <!-- BASIC INFO -->
-    <div class="col-lg-4">
+ <!-- BASIC INFO -->
+<div class="col-lg-4">
 
-        <section class="info-card basic-info-card h-100">
+    <section class="info-card basic-info-card h-100">
 
-            <div class="section-heading">
-                <i class="bi bi-person"></i>
-                Basic Info
+        <div class="section-heading">
+            <i class="bi bi-person"></i>
+            Basic Info
+        </div>
+
+        <div class="info-item">
+
+            <i class="bi bi-envelope"></i>
+
+            <div>
+                <div class="info-label">Email</div>
+
+                <div class="info-value">
+                    {{ current_user.email if current_user else 'Not available' }}
+                </div>
             </div>
 
-            <div class="info-item">
+        </div>
 
-                <i class="bi bi-envelope"></i>
+        <div class="info-item">
 
-                <div>
-                    <div class="info-label">Email</div>
+            <i class="bi bi-code-slash"></i>
 
-                    <div class="info-value">
-                        {{ current_user.email if current_user else 'Not available' }}
+            <div>
+                <div class="info-label">Major</div>
+
+                <div class="info-value">
+                    {{ current_user.major if current_user else 'Not available' }}
+                </div>
+            </div>
+
+        </div>
+
+        {% if current_user and current_user.second_major %}
+        <div class="info-item">
+
+            <i class="bi bi-diagram-3"></i>
+
+            <div>
+                <div class="info-label">Second Major</div>
+
+                <div class="info-value">
+                    {{ current_user.second_major }}
+                </div>
+            </div>
+
+        </div>
+        {% endif %}
+
+        {% if current_user and current_user.minor %}
+        <div class="info-item">
+
+            <i class="bi bi-bookmark-star"></i>
+
+            <div>
+                <div class="info-label">Minor</div>
+
+                <div class="info-value">
+                    {{ current_user.minor }}
+                </div>
+            </div>
+
+        </div>
+        {% endif %}
+
+        <div class="info-item">
+
+            <i class="bi bi-mortarboard"></i>
+
+            <div>
+                <div class="info-label">Degree</div>
+
+                <div class="info-value">
+                    {{ current_user.degree if current_user else 'Not available' }}
+                </div>
+            </div>
+
+        </div>
+
+    </section>
+
+</div>
+
+
+<!-- SUBJECTS -->
+<div class="col-lg-4">
+
+    <section class="info-card subjects-card h-100">
+
+        <div class="section-heading">
+            <i class="bi bi-book"></i>
+            Subjects
+        </div>
+
+        <div class="subject-container">
+
+            {% if units %}
+
+                {% for unit in units %}
+                    <span class="subject-chip">{{ unit }}</span>
+                {% endfor %}
+
+            {% else %}
+
+                <div class="empty-subject-state">
+
+                    <div class="empty-subject-icon">
+                        <i class="bi bi-book"></i>
                     </div>
+
+                    <p>No subjects added yet</p>
+
                 </div>
 
-            </div>
-
-            {% if current_user and current_user.second_major %}
-            <div class="info-item">
-
-                <i class="bi bi-diagram-3"></i>
-
-                <div>
-                    <div class="info-label">Second Major</div>
-
-                    <div class="info-value">
-                        {{ current_user.second_major }}
-                    </div>
-                </div>
-
-            </div>
             {% endif %}
 
-            {% if current_user and current_user.minor %}
-            <div class="info-item">
+        </div>
 
-                <i class="bi bi-bookmark-star"></i>
+    </section>
 
-                <div>
-                    <div class="info-label">Minor</div>
-
-                    <div class="info-value">
-                        {{ current_user.minor }}
-                    </div>
-                </div>
-
-            </div>
-            {% endif %}
-
-            <div class="info-item">
-
-                <i class="bi bi-mortarboard"></i>
-
-                <div>
-                    <div class="info-label">Degree</div>
-
-                    <div class="info-value">
-                        {{ current_user.degree if current_user else 'Not available' }}
-                    </div>
-                </div>
-
-            </div>
-
-            <div class="info-item">
-
-                <i class="bi bi-code-slash"></i>
-
-                <div>
-                    <div class="info-label">Major</div>
-
-                    <div class="info-value">
-                        {{ current_user.major if current_user else 'Not available' }}
-                    </div>
-                </div>
-
-            </div>
-
-        </section>
-
-    </div>
-
-    <!-- SUBJECTS -->
-    <div class="col-lg-4">
-
-        <section class="info-card subjects-card h-100">
-
-            <div class="section-heading">
-                <i class="bi bi-book"></i>
-                Subjects
-            </div>
-
-            <div class="subject-container">
-
-                {% if subjects %}
-
-                    {% for subject in subjects %}
-                        <span class="subject-chip">{{ subject }}</span>
-                    {% endfor %}
-
-                {% else %}
-
-                    <div class="empty-subject-state">
-
-                        <div class="empty-subject-icon">
-                            <i class="bi bi-book"></i>
-                        </div>
-
-                        <p>No subjects added yet</p>
-
-                    </div>
-
-                {% endif %}
-
-            </div>
-
-        </section>
-
-    </div>
+</div>
 
     <!-- AVAILABILITY -->
     <div class="col-lg-4">


### PR DESCRIPTION
- Removed duplicated matching helper functions
- Refined the academic matching logic so that second major matching with second major, primary major matching with primary major, and secondary major matching with primary major are treated equally.
- Changed authentication validation (email, username and password) to simply use wordings like 'format looks valid'
- Re-added some live validation messages in the signup page, which appeared to have been deleted. 
- added live validation to the reset password page as well
- Earlier, the basic info ordering on the profile page had email first, followed by second major/minor, then degree, and finally the primary major. This did not feel very intuitive, so I reorganised it to display email first, then major, followed by any second major or minor, and finally the degree.
