### PR TITLE
Add majors/minors autocomplete with local data sources

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -76,6 +76,38 @@ def load_valid_uwa_2026_unit_codes():
 VALID_UWA_2026_UNIT_CODES = load_valid_uwa_2026_unit_codes()
 
 
+def load_uwa_majors():
+    app_root = Path(current_app.root_path) if has_app_context() else Path(__file__).resolve().parent
+    data_path = app_root.parent / "data" / "uwa_majors.txt"
+    if not data_path.exists():
+        return []
+    majors = []
+    for line in data_path.read_text(encoding="utf-8").splitlines():
+        major = line.strip()
+        if major:
+            majors.append(major)
+    return sorted(set(majors), key=str.lower)
+
+
+UWA_MAJORS = load_uwa_majors()
+
+
+def load_uwa_minors():
+    app_root = Path(current_app.root_path) if has_app_context() else Path(__file__).resolve().parent
+    data_path = app_root.parent / "data" / "uwa_minors.txt"
+    if not data_path.exists():
+        return []
+    minors = []
+    for line in data_path.read_text(encoding="utf-8").splitlines():
+        minor = line.strip()
+        if minor:
+            minors.append(minor)
+    return sorted(set(minors), key=str.lower)
+
+
+UWA_MINORS = load_uwa_minors()
+
+
 def get_serializer():
     return URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
 
@@ -1409,6 +1441,32 @@ def search_units():
     ]
     matches.sort()
     return {"units": matches[:12]}
+
+
+@main_bp.route("/majors/search")
+def search_majors():
+    query = request.args.get("q", "").strip().lower()
+    if len(query) < 2:
+        return {"majors": []}
+
+    if not re.match(r"^[a-z0-9 '&/-]+$", query):
+        return {"majors": []}
+
+    matches = [major for major in UWA_MAJORS if query in major.lower()]
+    return {"majors": matches[:12]}
+
+
+@main_bp.route("/minors/search")
+def search_minors():
+    query = request.args.get("q", "").strip().lower()
+    if len(query) < 2:
+        return {"minors": []}
+
+    if not re.match(r"^[a-z0-9 '&/-]+$", query):
+        return {"minors": []}
+
+    matches = [minor for minor in UWA_MINORS if query in minor.lower()]
+    return {"minors": matches[:12]}
 
 
 @main_bp.route("/register", methods=["GET", "POST"])

--- a/app/routes.py
+++ b/app/routes.py
@@ -196,9 +196,28 @@ def get_onboarding_target_endpoint(user):
 
 
 def can_finish_onboarding(user):
-    has_subject = UserSubject.query.filter_by(user_id=user.id).first() is not None
+    has_degree = bool((user.degree or "").strip()) or user.degree_option_id is not None
+
+    subjects = UserSubject.query.filter_by(user_id=user.id).all()
+    subject_codes = [subject.subject_code.strip().upper() for subject in subjects if subject.subject_code]
+
+    if len(subject_codes) > MAX_PROFILE_UNITS:
+        return False
+
+    if len(subject_codes) != len(set(subject_codes)):
+        return False
+
+    if not subject_codes:
+        return False
+
+    for code in subject_codes:
+        if not UNIT_CODE_PATTERN.match(code):
+            return False
+        if VALID_UWA_2026_UNIT_CODES and code not in VALID_UWA_2026_UNIT_CODES:
+            return False
+
     has_availability = UserAvailability.query.filter_by(user_id=user.id).first() is not None
-    return has_subject and has_availability
+    return has_degree and has_availability
 
 
 @main_bp.app_context_processor
@@ -833,7 +852,10 @@ def onboarding_advance():
         current_user.onboarding_step = max(1, step - 1)
     elif action == "finish":
         if not can_finish_onboarding(current_user):
-            flash("Before finishing, add at least one unit and one availability slot in Profile.", "error")
+            flash(
+                "Before finishing, ensure degree is set and add valid units (max 6, unique UWA codes) plus at least one availability slot in Profile.",
+                "error",
+            )
             current_user.onboarding_step = max_step
             db.session.commit()
             return redirect(url_for("main.profile"))

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -206,10 +206,15 @@
 
                     <input
                         type="text"
+                        id="major"
                         name="major"
+                        class="major-autocomplete"
                         placeholder="Enter your major"
+                        autocomplete="off"
+                        list="majorSuggestions"
                         required
                     >
+                    <datalist id="majorSuggestions"></datalist>
 
                 </div>
 
@@ -226,8 +231,12 @@
 
                         <input
                             type="text"
+                            id="second-major"
                             name="second_major"
+                            class="major-autocomplete"
                             placeholder="Enter second major"
+                            autocomplete="off"
+                            list="majorSuggestions"
                         >
 
                     </div>
@@ -243,9 +252,14 @@
 
                         <input
                             type="text"
+                            id="minor"
                             name="minor"
+                            class="minor-autocomplete"
                             placeholder="Enter minor"
+                            autocomplete="off"
+                            list="minorSuggestions"
                         >
+                        <datalist id="minorSuggestions"></datalist>
 
                     </div>
 
@@ -542,6 +556,12 @@
 
         let emailTimer;
         let usernameTimer;
+        let majorTimer;
+        let minorTimer;
+        const majorInputs = document.querySelectorAll('.major-autocomplete');
+        const majorSuggestions = document.getElementById('majorSuggestions');
+        const minorInputs = document.querySelectorAll('.minor-autocomplete');
+        const minorSuggestions = document.getElementById('minorSuggestions');
 
         emailInput.addEventListener("input", function() {
             clearTimeout(emailTimer);
@@ -568,6 +588,54 @@
             checkConfirmPassword();
         });
 
+        majorInputs.forEach((input) => {
+            input.addEventListener('input', () => {
+                const query = input.value.trim();
+
+                if (query.length < 2) {
+                    majorSuggestions.innerHTML = '';
+                    return;
+                }
+
+                clearTimeout(majorTimer);
+                majorTimer = setTimeout(async () => {
+                    try {
+                        const response = await fetch(`{{ url_for('main.search_majors') }}?q=${encodeURIComponent(query)}`);
+                        if (!response.ok) return;
+                        const payload = await response.json();
+                        const majors = Array.isArray(payload.majors) ? payload.majors : [];
+                        majorSuggestions.innerHTML = majors.map((major) => `<option value="${major}"></option>`).join('');
+                    } catch (_error) {
+                        majorSuggestions.innerHTML = '';
+                    }
+                }, 120);
+            });
+        });
+
+        minorInputs.forEach((input) => {
+            input.addEventListener('input', () => {
+                const query = input.value.trim();
+
+                if (query.length < 2) {
+                    minorSuggestions.innerHTML = '';
+                    return;
+                }
+
+                clearTimeout(minorTimer);
+                minorTimer = setTimeout(async () => {
+                    try {
+                        const response = await fetch(`{{ url_for('main.search_minors') }}?q=${encodeURIComponent(query)}`);
+                        if (!response.ok) return;
+                        const payload = await response.json();
+                        const minors = Array.isArray(payload.minors) ? payload.minors : [];
+                        minorSuggestions.innerHTML = minors.map((minor) => `<option value="${minor}"></option>`).join('');
+                    } catch (_error) {
+                        minorSuggestions.innerHTML = '';
+                    }
+                }, 120);
+            });
+        });
+
         form.addEventListener("submit", async function(event) {
             formError.textContent = "";
 
@@ -592,4 +660,3 @@
 
 </body>
 </html>
-

--- a/app/templates/userpages.html
+++ b/app/templates/userpages.html
@@ -350,18 +350,18 @@
                                 </div>
                                 <div class="col-md-6">
                                     <label class="form-label">Major</label>
-                                    <input name="major" class="form-control" value="{{ current_user.major if current_user else '' }}" required>
+                                    <input name="major" class="form-control major-autocomplete" value="{{ current_user.major if current_user else '' }}" autocomplete="off" list="majorSuggestions" required>
                                 </div>
                             </div>
 
                             <div class="row g-3 mb-3">
                                 <div class="col-md-6">
                                     <label class="form-label">Second Major</label>
-                                    <input name="second_major" class="form-control" value="{{ current_user.second_major if current_user and current_user.second_major else '' }}">
+                                    <input name="second_major" class="form-control major-autocomplete" value="{{ current_user.second_major if current_user and current_user.second_major else '' }}" autocomplete="off" list="majorSuggestions">
                                 </div>
                                 <div class="col-md-6">
                                     <label class="form-label">Minor</label>
-                                    <input name="minor" class="form-control" value="{{ current_user.minor if current_user and current_user.minor else '' }}">
+                                    <input name="minor" class="form-control minor-autocomplete" value="{{ current_user.minor if current_user and current_user.minor else '' }}" autocomplete="off" list="minorSuggestions">
                                 </div>
                             </div>
 
@@ -396,6 +396,8 @@
                                 <label class="form-label">About</label>
                                 <textarea name="bio" class="form-control" rows="3">{{ current_user.bio if current_user and current_user.bio else '' }}</textarea>
                             </div>
+                            <datalist id="majorSuggestions"></datalist>
+                            <datalist id="minorSuggestions"></datalist>
                         </div>
 
                         <div class="tab-pane fade" id="tab-units" role="tabpanel">
@@ -626,6 +628,10 @@
 
     let autocompleteTimer;
     const unitSearchUrl = "{{ url_for('main.search_units') }}";
+    let majorTimer;
+    const majorSearchUrl = "{{ url_for('main.search_majors') }}";
+    let minorTimer;
+    const minorSearchUrl = "{{ url_for('main.search_minors') }}";
 
     document.addEventListener('input', (event) => {
         const input = event.target;
@@ -651,6 +657,60 @@
                 const payload = await response.json();
                 const units = Array.isArray(payload.units) ? payload.units : [];
                 list.innerHTML = units.map((unit) => `<option value="${unit}"></option>`).join('');
+            } catch (_error) {
+                list.innerHTML = '';
+            }
+        }, 120);
+    });
+
+    document.addEventListener('input', (event) => {
+        const input = event.target;
+        if (!input.classList.contains('major-autocomplete')) return;
+
+        const query = input.value.trim();
+        const list = document.getElementById('majorSuggestions');
+        if (!list) return;
+
+        if (query.length < 2) {
+            list.innerHTML = '';
+            return;
+        }
+
+        clearTimeout(majorTimer);
+        majorTimer = setTimeout(async () => {
+            try {
+                const response = await fetch(`${majorSearchUrl}?q=${encodeURIComponent(query)}`);
+                if (!response.ok) return;
+                const payload = await response.json();
+                const majors = Array.isArray(payload.majors) ? payload.majors : [];
+                list.innerHTML = majors.map((major) => `<option value="${major}"></option>`).join('');
+            } catch (_error) {
+                list.innerHTML = '';
+            }
+        }, 120);
+    });
+
+    document.addEventListener('input', (event) => {
+        const input = event.target;
+        if (!input.classList.contains('minor-autocomplete')) return;
+
+        const query = input.value.trim();
+        const list = document.getElementById('minorSuggestions');
+        if (!list) return;
+
+        if (query.length < 2) {
+            list.innerHTML = '';
+            return;
+        }
+
+        clearTimeout(minorTimer);
+        minorTimer = setTimeout(async () => {
+            try {
+                const response = await fetch(`${minorSearchUrl}?q=${encodeURIComponent(query)}`);
+                if (!response.ok) return;
+                const payload = await response.json();
+                const minors = Array.isArray(payload.minors) ? payload.minors : [];
+                list.innerHTML = minors.map((minor) => `<option value="${minor}"></option>`).join('');
             } catch (_error) {
                 list.innerHTML = '';
             }

--- a/data/uwa_majors.txt
+++ b/data/uwa_majors.txt
@@ -1,0 +1,67 @@
+Accounting
+Agricultural Science
+Anatomy and Human Biology
+Anthropology and Sociology
+Applied Mathematics
+Archaeology
+Architecture
+Art History
+Artificial Intelligence
+Asian Studies
+Biochemistry
+Biological Science
+Biomedical Science
+Botany
+Business Analytics
+Chemical Engineering
+Chemistry
+Chinese Studies
+Civil Engineering
+Classics and Ancient History
+Communication and Media Studies
+Computer Science
+Conservation Biology
+Criminology
+Cybersecurity
+Data Science
+Economics
+Electrical and Electronic Engineering
+Engineering Science
+English and Literary Studies
+Environmental Engineering
+Environmental Science
+Finance
+French Studies
+Genetics
+Geography
+Geology
+German Studies
+History
+Human Resource Management
+Indigenous Knowledge, History and Heritage
+Indonesian Studies
+International Relations
+Italian Studies
+Japanese Studies
+Law and Society
+Linguistics
+Management
+Marine Biology
+Marketing
+Mathematics and Statistics
+Mechanical Engineering
+Microbiology and Immunology
+Music Studies
+Neuroscience
+Pathology and Laboratory Medicine
+Pharmacology
+Philosophy
+Physics
+Political Science and International Relations
+Population Health
+Psychology
+Software Engineering
+Sport Science
+Statistics
+Theatre and Performance Studies
+Zoology

--- a/scripts/extract_uwa_majors.py
+++ b/scripts/extract_uwa_majors.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import html
+import re
+from pathlib import Path
+
+import certifi
+import requests
+
+
+MAJORS_URL = "https://www.handbooks.uwa.edu.au/majors"
+OUTPUT_FILE = Path("data/uwa_majors.txt")
+MAJOR_LINK_PATTERN = re.compile(r'href="/majors/[^"]+"[^>]*>([^<]+)</a>', re.IGNORECASE)
+
+
+response = requests.get(MAJORS_URL, timeout=30, verify=certifi.where())
+response.raise_for_status()
+page_text = response.text
+
+majors = set()
+for match in MAJOR_LINK_PATTERN.findall(page_text):
+    label = html.unescape(match)
+    label = re.sub(r"\s+", " ", label).strip()
+    if label:
+        majors.add(label)
+
+sorted_majors = sorted(majors, key=str.lower)
+
+OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+OUTPUT_FILE.write_text("\n".join(sorted_majors) + "\n", encoding="utf-8")
+
+print(f"Extracted {len(sorted_majors)} majors to {OUTPUT_FILE}")

--- a/scripts/extract_uwa_minors.py
+++ b/scripts/extract_uwa_minors.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import html
+import re
+from pathlib import Path
+
+import certifi
+import requests
+
+
+MINORS_URL = "https://www.handbooks.uwa.edu.au/minors"
+OUTPUT_FILE = Path("data/uwa_minors.txt")
+MINOR_LINK_PATTERN = re.compile(r'href="/minors/[^"]+"[^>]*>([^<]+)</a>', re.IGNORECASE)
+
+
+response = requests.get(MINORS_URL, timeout=30, verify=certifi.where())
+response.raise_for_status()
+page_text = response.text
+
+minors = set()
+for match in MINOR_LINK_PATTERN.findall(page_text):
+    label = html.unescape(match)
+    label = re.sub(r"\s+", " ", label).strip()
+    if label:
+        minors.add(label)
+
+sorted_minors = sorted(minors, key=str.lower)
+
+OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+OUTPUT_FILE.write_text("\n".join(sorted_minors) + "\n", encoding="utf-8")
+
+print(f"Extracted {len(sorted_minors)} minors to {OUTPUT_FILE}")


### PR DESCRIPTION
- Adds autocomplete for major, second_major, and minor fields in both registration and profile edit flows.  
- Introduces local dataset-driven search endpoints for majors/minors to keep suggestions fast and consistent without external runtime dependencies.  
- Adds simple extraction scripts to regenerate handbook data files in data/ when needed.
- Adds the unit and major autocomplete to the onboarding aas well