### PR TITLE
Fix 'Other' degree registration validation and add current page sidebar highlighting

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -30,37 +30,37 @@
                 </div>
 
                 <a href="{{ url_for('main.dashboard') }}"
-                    class="{% if request.endpoint == 'dashboard' %}active{% endif %}">
+                    class="{% if request.endpoint == 'main.dashboarddashboard' %}active{% endif %}">
                     <i class="bi bi-grid"></i>
                     Dashboard
                 </a>
 
                 <a href="{{ url_for('main.profile') }}"
-                    class="{% if request.endpoint == 'profile' %}active{% endif %}">
+                    class="{% if request.endpoint == 'main.profile' %}active{% endif %}">
                     <i class="bi bi-person"></i>
                     Profile
                 </a>
 
                 <a href="{{ url_for('main.matches') }}"
-                    class="{% if request.endpoint == 'matches' %}active{% endif %}">
+                    class="{% if request.endpoint == 'main.matches' %}active{% endif %}">
                     <i class="bi bi-people"></i>
                     Matches
                 </a>
 
                 <a href="{{ url_for('main.events_page') }}"
-                    class="{% if request.endpoint == 'events_page' %}active{% endif %}">
+                    class="{% if request.endpoint == 'main.events_page' %}active{% endif %}">
                     <i class="bi bi-calendar-event"></i>
                     Events
                 </a>
 
                 <a href="{{ url_for('main.notifications') }}"
-                    class="{% if request.endpoint == 'notifications' %}active{% endif %}">
+                    class="{% if request.endpoint == 'main.notifications' %}active{% endif %}">
                     <i class="bi bi-bell"></i>
                     Notifications
                 </a>
 
                 <a href="{{ url_for('main.messages_inbox') }}"
-                    class="{% if request.endpoint == 'messages_inbox' %}active{% endif %}">
+                    class="{% if request.endpoint == 'main.messages_inbox' %}active{% endif %}">
                     <i class="bi bi-chat"></i>
                      Messages
                 </a>

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -361,7 +361,11 @@
             otherInput.required = false;
             otherInput.value = "";
 
+            degreeSelect.required = true;
+
             if (type === "other") {
+
+                degreeSelect.required = false;
 
                 degreeSelect.innerHTML =
                     '<option value="" selected>Other (enter below)</option>';


### PR DESCRIPTION
- Fixed the registration form validation logic when users select "Other" under Degree Type using the proposed solution mentioned in issue #140 
- The degree dropdown is no longer treated as required when "Other" is selected.
- Made the sidebar highlight the page the user is currently on to enhance user experience

