### PR TITLE
Add People search and mutual friend request workflow

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -260,6 +260,20 @@ class Invitation(db.Model):
         db.UniqueConstraint("sender_id", "receiver_id", "conversation_id", name="uq_invitation"),
     )
 
+
+class FriendRequest(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_low_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    user_high_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    requested_by_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="pending")
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        db.UniqueConstraint("user_low_id", "user_high_id", name="uq_friend_pair"),
+    )
+
     def __repr__(self):
         return f"<Invitation {self.id} from {self.sender_id} to {self.receiver_id} [{self.status}]>"
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -19,6 +19,7 @@ from .database import (
     DegreeOption,
     Event,
     EventAttendee,
+    FriendRequest,
     Invitation,
     Message,
     MessageRead,
@@ -182,6 +183,15 @@ def get_current_user():
     if not current_user.is_authenticated:
         return None
     return current_user
+
+
+def get_friend_pair_ids(user_a_id, user_b_id):
+    return (user_a_id, user_b_id) if user_a_id < user_b_id else (user_b_id, user_a_id)
+
+
+def get_friend_request_between(user_a_id, user_b_id):
+    low_id, high_id = get_friend_pair_ids(user_a_id, user_b_id)
+    return FriendRequest.query.filter_by(user_low_id=low_id, user_high_id=high_id).first()
 
 
 def get_onboarding_step_for_user(user):
@@ -1303,6 +1313,218 @@ def matches():
         selected_unit_codes=selected_unit_codes,
         message=message,
     )
+
+
+@main_bp.route("/people")
+@login_required
+def people():
+    query = request.args.get("q", "").strip()
+    active_tab = request.args.get("tab", "discover")
+    if active_tab not in {"discover", "friends"}:
+        active_tab = "discover"
+
+    search_results = []
+    if len(query) >= 2:
+        matches = (
+            User.query
+            .filter(User.id != current_user.id)
+            .filter(User.username.ilike(f"{query}%"))
+            .order_by(User.username.asc())
+            .limit(20)
+            .all()
+        )
+
+        candidate_ids = [user.id for user in matches]
+        relationship_rows = []
+        if candidate_ids:
+            relationship_rows = FriendRequest.query.filter(
+                or_(
+                    (FriendRequest.user_low_id == current_user.id) & FriendRequest.user_high_id.in_(candidate_ids),
+                    (FriendRequest.user_high_id == current_user.id) & FriendRequest.user_low_id.in_(candidate_ids),
+                )
+            ).all()
+
+        relationship_map = {}
+        for relation in relationship_rows:
+            other_user_id = relation.user_high_id if relation.user_low_id == current_user.id else relation.user_low_id
+            relationship_map[other_user_id] = relation
+
+        for user in matches:
+            relation = relationship_map.get(user.id)
+            relation_state = "none"
+
+            if relation is not None:
+                if relation.status == "pending":
+                    if relation.requested_by_id == current_user.id:
+                        relation_state = "outgoing_pending"
+                    else:
+                        relation_state = "incoming_pending"
+                elif relation.status == "accepted":
+                    relation_state = "accepted"
+
+            search_results.append({
+                "user": user,
+                "state": relation_state,
+                "friend_request_id": relation.id if relation else None,
+            })
+
+    incoming_requests = (
+        FriendRequest.query.filter(FriendRequest.status == "pending")
+        .filter(FriendRequest.requested_by_id != current_user.id)
+        .filter(
+            or_(
+                FriendRequest.user_low_id == current_user.id,
+                FriendRequest.user_high_id == current_user.id,
+            )
+        )
+        .order_by(FriendRequest.created_at.desc())
+        .limit(50)
+        .all()
+    )
+
+    outgoing_requests = (
+        FriendRequest.query.filter_by(status="pending", requested_by_id=current_user.id)
+        .order_by(FriendRequest.created_at.desc())
+        .limit(50)
+        .all()
+    )
+
+    accepted_relationships = (
+        FriendRequest.query.filter_by(status="accepted")
+        .filter(
+            or_(
+                FriendRequest.user_low_id == current_user.id,
+                FriendRequest.user_high_id == current_user.id,
+            )
+        )
+        .order_by(FriendRequest.updated_at.desc())
+        .limit(50)
+        .all()
+    )
+
+    def other_user(friend_request):
+        other_id = friend_request.user_high_id if friend_request.user_low_id == current_user.id else friend_request.user_low_id
+        return db.session.get(User, other_id)
+
+    incoming_payload = [{"request": item, "user": other_user(item)} for item in incoming_requests]
+    outgoing_payload = [{"request": item, "user": other_user(item)} for item in outgoing_requests]
+    accepted_payload = [{"request": item, "user": other_user(item)} for item in accepted_relationships]
+
+    return render_template(
+        "people.html",
+        current_user=current_user,
+        query=query,
+        active_tab=active_tab,
+        search_results=search_results,
+        incoming_requests=incoming_payload,
+        outgoing_requests=outgoing_payload,
+        friends=accepted_payload,
+    )
+
+
+@main_bp.route("/friends/request/<int:user_id>", methods=["POST"])
+@login_required
+def send_friend_request(user_id):
+    if user_id == current_user.id:
+        flash("You cannot send a friend request to yourself.", "error")
+        return redirect(url_for("main.people", tab="discover"))
+
+    target_user = db.session.get(User, user_id)
+    if target_user is None:
+        flash("User not found.", "error")
+        return redirect(url_for("main.people", tab="discover"))
+
+    existing = get_friend_request_between(current_user.id, user_id)
+    if existing is None:
+        low_id, high_id = get_friend_pair_ids(current_user.id, user_id)
+        db.session.add(
+            FriendRequest(
+                user_low_id=low_id,
+                user_high_id=high_id,
+                requested_by_id=current_user.id,
+                status="pending",
+            )
+        )
+        db.session.commit()
+        flash("Friend request sent.", "success")
+        return redirect(url_for("main.people", tab="discover"))
+
+    if existing.status == "pending":
+        flash("A friend request is already pending.", "info")
+        return redirect(url_for("main.people", tab="discover"))
+
+    if existing.status == "accepted":
+        flash("You are already friends.", "info")
+        return redirect(url_for("main.people", tab="discover"))
+
+    existing.requested_by_id = current_user.id
+    existing.status = "pending"
+    db.session.commit()
+    flash("Friend request sent.", "success")
+    return redirect(url_for("main.people", tab="discover"))
+
+
+@main_bp.route("/friends/<int:friend_request_id>/accept", methods=["POST"])
+@login_required
+def accept_friend_request(friend_request_id):
+    friend_request = FriendRequest.query.get_or_404(friend_request_id)
+
+    if friend_request.status != "pending":
+        flash("This friend request is no longer pending.", "info")
+        return redirect(url_for("main.people", tab="friends"))
+
+    if friend_request.requested_by_id == current_user.id:
+        abort(403)
+
+    if current_user.id not in {friend_request.user_low_id, friend_request.user_high_id}:
+        abort(403)
+
+    friend_request.status = "accepted"
+    db.session.commit()
+    flash("Friend request accepted.", "success")
+    return redirect(url_for("main.people", tab="friends"))
+
+
+@main_bp.route("/friends/<int:friend_request_id>/reject", methods=["POST"])
+@login_required
+def reject_friend_request(friend_request_id):
+    friend_request = FriendRequest.query.get_or_404(friend_request_id)
+
+    if friend_request.status != "pending":
+        flash("This friend request is no longer pending.", "info")
+        return redirect(url_for("main.people", tab="friends"))
+
+    if friend_request.requested_by_id == current_user.id:
+        abort(403)
+
+    if current_user.id not in {friend_request.user_low_id, friend_request.user_high_id}:
+        abort(403)
+
+    friend_request.status = "rejected"
+    db.session.commit()
+    flash("Friend request rejected.", "info")
+    return redirect(url_for("main.people", tab="friends"))
+
+
+@main_bp.route("/friends/<int:friend_request_id>/cancel", methods=["POST"])
+@login_required
+def cancel_friend_request(friend_request_id):
+    friend_request = FriendRequest.query.get_or_404(friend_request_id)
+
+    if friend_request.status != "pending":
+        flash("This friend request is no longer pending.", "info")
+        return redirect(url_for("main.people", tab="friends"))
+
+    if friend_request.requested_by_id != current_user.id:
+        abort(403)
+
+    if current_user.id not in {friend_request.user_low_id, friend_request.user_high_id}:
+        abort(403)
+
+    friend_request.status = "cancelled"
+    db.session.commit()
+    flash("Friend request cancelled.", "info")
+    return redirect(url_for("main.people", tab="friends"))
 
 
 @main_bp.route("/profile", methods=["GET", "POST"])

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -47,6 +47,12 @@
                     Matches
                 </a>
 
+                <a href="{{ url_for('main.people') }}"
+                    class="{% if request.endpoint == 'main.people' %}active{% endif %}">
+                    <i class="bi bi-person-lines-fill"></i>
+                    People
+                </a>
+
                 <a href="{{ url_for('main.events_page') }}"
                     class="{% if request.endpoint == 'main.events_page' %}active{% endif %}">
                     <i class="bi bi-calendar-event"></i>

--- a/app/templates/people.html
+++ b/app/templates/people.html
@@ -1,0 +1,151 @@
+{% extends "base.html" %}
+{% block title %}People{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div>
+        <h1>People</h1>
+        <p>Find users by username and manage friend requests.</p>
+    </div>
+</div>
+
+<section class="info-card mb-4">
+    <ul class="nav nav-tabs mb-3" role="tablist">
+        <li class="nav-item" role="presentation">
+            <a class="nav-link {% if active_tab == 'discover' %}active{% endif %}" href="{{ url_for('main.people', tab='discover', q=query) }}">Discover</a>
+        </li>
+        <li class="nav-item" role="presentation">
+            <a class="nav-link {% if active_tab == 'friends' %}active{% endif %}" href="{{ url_for('main.people', tab='friends') }}">Friends</a>
+        </li>
+    </ul>
+
+    {% if active_tab == 'discover' %}
+    <form method="GET" action="{{ url_for('main.people') }}" class="row g-3 align-items-end">
+        <input type="hidden" name="tab" value="discover">
+        <div class="col-md-8">
+            <label for="peopleSearch" class="form-label">Search by username</label>
+            <input id="peopleSearch" name="q" class="form-control" placeholder="Type at least 2 characters" value="{{ query }}">
+        </div>
+        <div class="col-md-4">
+            <button type="submit" class="btn btn-primary w-100">Search</button>
+        </div>
+    </form>
+
+    {% if query and query|length < 2 %}
+    <p class="mt-3 mb-0 text-muted">Enter at least 2 characters to search.</p>
+    {% elif query and not search_results %}
+    <p class="mt-3 mb-0 text-muted">No users found.</p>
+    {% endif %}
+
+    {% for row in search_results %}
+    <section class="info-card mt-3">
+        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+            <div>
+                <h5 class="mb-1">{{ row.user.username }}</h5>
+                <div class="text-muted">{{ row.user.first_name }} {{ row.user.last_name }}</div>
+            </div>
+            <div class="d-flex gap-2">
+                <form method="POST" action="{{ url_for('main.start_conversation', receiver_id=row.user.id) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-outline-light btn-sm">Message</button>
+                </form>
+
+                {% if row.state == 'none' %}
+                <form method="POST" action="{{ url_for('main.send_friend_request', user_id=row.user.id) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-primary btn-sm">Add Friend</button>
+                </form>
+                {% elif row.state == 'outgoing_pending' %}
+                <button type="button" class="btn btn-secondary btn-sm" disabled>Pending</button>
+                <form method="POST" action="{{ url_for('main.cancel_friend_request', friend_request_id=row.friend_request_id) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-outline-warning btn-sm">Cancel</button>
+                </form>
+                {% elif row.state == 'incoming_pending' %}
+                <form method="POST" action="{{ url_for('main.accept_friend_request', friend_request_id=row.friend_request_id) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-success btn-sm">Accept</button>
+                </form>
+                <form method="POST" action="{{ url_for('main.reject_friend_request', friend_request_id=row.friend_request_id) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-outline-danger btn-sm">Reject</button>
+                </form>
+                {% elif row.state == 'accepted' %}
+                <button type="button" class="btn btn-success btn-sm" disabled>Friends</button>
+                {% endif %}
+            </div>
+        </div>
+    </section>
+    {% endfor %}
+    {% endif %}
+
+    {% if active_tab == 'friends' %}
+    <div class="row g-3">
+        <div class="col-lg-4">
+            <section class="info-card h-100">
+                <h5>Incoming Requests</h5>
+                {% if incoming_requests %}
+                    {% for row in incoming_requests %}
+                    <div class="mt-3 d-flex justify-content-between align-items-center gap-2 flex-wrap">
+                        <div>{{ row.user.username if row.user else 'Unknown user' }}</div>
+                        <div class="d-flex gap-2">
+                            <form method="POST" action="{{ url_for('main.accept_friend_request', friend_request_id=row.request.id) }}">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-success btn-sm">Accept</button>
+                            </form>
+                            <form method="POST" action="{{ url_for('main.reject_friend_request', friend_request_id=row.request.id) }}">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-outline-danger btn-sm">Reject</button>
+                            </form>
+                        </div>
+                    </div>
+                    {% endfor %}
+                {% else %}
+                <p class="mb-0 text-muted mt-2">No incoming requests.</p>
+                {% endif %}
+            </section>
+        </div>
+
+        <div class="col-lg-4">
+            <section class="info-card h-100">
+                <h5>Outgoing Requests</h5>
+                {% if outgoing_requests %}
+                    {% for row in outgoing_requests %}
+                    <div class="mt-3 d-flex justify-content-between align-items-center gap-2 flex-wrap">
+                        <div>{{ row.user.username if row.user else 'Unknown user' }}</div>
+                        <form method="POST" action="{{ url_for('main.cancel_friend_request', friend_request_id=row.request.id) }}">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="btn btn-outline-warning btn-sm">Cancel</button>
+                        </form>
+                    </div>
+                    {% endfor %}
+                {% else %}
+                <p class="mb-0 text-muted mt-2">No outgoing requests.</p>
+                {% endif %}
+            </section>
+        </div>
+
+        <div class="col-lg-4">
+            <section class="info-card h-100">
+                <h5>Friends</h5>
+                {% if friends %}
+                    {% for row in friends %}
+                    <div class="mt-3 d-flex justify-content-between align-items-center gap-2 flex-wrap">
+                        <div>{{ row.user.username if row.user else 'Unknown user' }}</div>
+                        {% if row.user %}
+                        <form method="POST" action="{{ url_for('main.start_conversation', receiver_id=row.user.id) }}">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="btn btn-outline-light btn-sm">Message</button>
+                        </form>
+                        {% endif %}
+                    </div>
+                    {% endfor %}
+                {% else %}
+                <p class="mb-0 text-muted mt-2">No friends yet.</p>
+                {% endif %}
+            </section>
+        </div>
+    </div>
+    {% endif %}
+</section>
+{% endblock %}

--- a/migrations/versions/9f1c2a3b4d5e_add_friend_requests_table.py
+++ b/migrations/versions/9f1c2a3b4d5e_add_friend_requests_table.py
@@ -1,0 +1,38 @@
+"""add friend requests table
+
+Revision ID: 9f1c2a3b4d5e
+Revises: 6b11089fb8d5
+Create Date: 2026-05-15 11:20:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "9f1c2a3b4d5e"
+down_revision = "6b11089fb8d5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "friend_request",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_low_id", sa.Integer(), nullable=False),
+        sa.Column("user_high_id", sa.Integer(), nullable=False),
+        sa.Column("requested_by_id", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["requested_by_id"], ["user.id"]),
+        sa.ForeignKeyConstraint(["user_high_id"], ["user.id"]),
+        sa.ForeignKeyConstraint(["user_low_id"], ["user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_low_id", "user_high_id", name="uq_friend_pair"),
+    )
+
+
+def downgrade():
+    op.drop_table("friend_request")

--- a/tests/test_people_unit.py
+++ b/tests/test_people_unit.py
@@ -1,0 +1,151 @@
+import os
+import unittest
+
+os.environ["DATABASE_URL"] = os.environ.get("TEST_DATABASE_URL", "sqlite:///:memory:")
+
+from app import app, db
+from app.database import FriendRequest, User
+from config import TestConfig
+
+
+class PeopleUnitTests(unittest.TestCase):
+    def setUp(self):
+        app.config.from_object(TestConfig)
+        self.client = app.test_client()
+
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
+            db.create_all()
+
+            self.user_a = self._create_user("alice", "alice@example.com")
+            self.user_b = self._create_user("albert", "albert@example.com")
+            self.user_c = self._create_user("bob", "bob@example.com")
+            self.user_d = self._create_user("alex", "alex@example.com")
+            db.session.commit()
+            self.user_a_id = self.user_a.id
+            self.user_b_id = self.user_b.id
+            self.user_c_id = self.user_c.id
+            self.user_d_id = self.user_d.id
+
+    def tearDown(self):
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def _create_user(self, username, email):
+        user = User(
+            first_name=username.capitalize(),
+            last_name="User",
+            email=email,
+            username=username,
+            degree="Computer Science",
+            major="Computer Science",
+            onboarding_completed=True,
+        )
+        user.set_password("password123")
+        db.session.add(user)
+        return user
+
+    def _login(self, username="alice", password="password123"):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=True,
+        )
+
+    def test_people_route_requires_authentication(self):
+        response = self.client.get("/people", follow_redirects=False)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login", response.headers.get("Location", ""))
+
+    def test_username_search_prefix_case_insensitive_and_excludes_self(self):
+        self._login("alice")
+        response = self.client.get("/people?tab=discover&q=Al", follow_redirects=True)
+        body = response.get_data(as_text=True)
+
+        self.assertIn("albert", body)
+        self.assertIn("alex", body)
+        self.assertNotIn('<h5 class="mb-1">alice</h5>', body)
+        self.assertNotIn("bob", body)
+
+    def test_username_search_requires_two_characters(self):
+        self._login("alice")
+        response = self.client.get("/people?tab=discover&q=a", follow_redirects=True)
+        self.assertIn("Enter at least 2 characters to search.", response.get_data(as_text=True))
+
+    def test_send_friend_request_creates_pending(self):
+        self._login("alice")
+        response = self.client.post(f"/friends/request/{self.user_b_id}", follow_redirects=True)
+        self.assertIn("Friend request sent.", response.get_data(as_text=True))
+
+        with app.app_context():
+            relation = FriendRequest.query.one()
+            self.assertEqual(relation.status, "pending")
+            self.assertEqual(relation.requested_by_id, self.user_a_id)
+
+    def test_duplicate_pending_request_is_blocked(self):
+        self._login("alice")
+        self.client.post(f"/friends/request/{self.user_b_id}", follow_redirects=True)
+        response = self.client.post(f"/friends/request/{self.user_b_id}", follow_redirects=True)
+
+        self.assertIn("already pending", response.get_data(as_text=True))
+        with app.app_context():
+            self.assertEqual(FriendRequest.query.count(), 1)
+
+    def test_accept_incoming_friend_request(self):
+        self._login("alice")
+        self.client.post(f"/friends/request/{self.user_b_id}", follow_redirects=True)
+
+        self.client.get("/logout", follow_redirects=True)
+        self._login("albert")
+
+        with app.app_context():
+            relation = FriendRequest.query.one()
+            relation_id = relation.id
+
+        self.client.post(f"/friends/{relation_id}/accept", follow_redirects=True)
+
+        with app.app_context():
+            relation = FriendRequest.query.one()
+            self.assertEqual(relation.status, "accepted")
+
+    def test_reject_then_rerequest_allowed(self):
+        self._login("alice")
+        self.client.post(f"/friends/request/{self.user_b_id}", follow_redirects=True)
+
+        self.client.get("/logout", follow_redirects=True)
+        self._login("albert")
+
+        with app.app_context():
+            relation = FriendRequest.query.one()
+            relation_id = relation.id
+
+        self.client.post(f"/friends/{relation_id}/reject", follow_redirects=True)
+        self.client.get("/logout", follow_redirects=True)
+
+        self._login("alice")
+        self.client.post(f"/friends/request/{self.user_b.id}", follow_redirects=True)
+
+        with app.app_context():
+            relation = FriendRequest.query.one()
+            self.assertEqual(relation.status, "pending")
+            self.assertEqual(relation.requested_by_id, self.user_a_id)
+
+    def test_cancel_outgoing_friend_request(self):
+        self._login("alice")
+        self.client.post(f"/friends/request/{self.user_b_id}", follow_redirects=True)
+
+        with app.app_context():
+            relation = FriendRequest.query.one()
+            relation_id = relation.id
+
+        self.client.post(f"/friends/{relation_id}/cancel", follow_redirects=True)
+
+        with app.app_context():
+            relation = FriendRequest.query.one()
+            self.assertEqual(relation.status, "cancelled")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a new People search feature that lets users find others by username prefix, send/cancel/respond to friend requests, and view incoming/outgoing/friend lists in one place. 
It introduces the FriendRequest model/migration, new People/friendship routes, sidebar navigation entry, and unit tests for search and request lifecycle behaviors