### PR TITLE
Match Search Results Rework

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3733,6 +3733,10 @@ body {
     color: #ffffff;
 }
 
+.glass-modal .text-muted {
+    color: rgba(216, 222, 252, 0.7) !important;
+}
+
 .glass-modal .modal-header {
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
     padding: 24px 30px;

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3695,9 +3695,8 @@ body {
                 0 0 20px rgba(139, 92, 246, 0.15);
 }
 
-.match-card-simplified .card-content {
-    position: relative;
-    z-index: 2;
+.match-card-simplified .text-muted {
+    color: rgba(216, 222, 252, 0.7) !important;
 }
 
 /* Initials Avatar */

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3675,3 +3675,141 @@ body {
     }
 }
 
+/* ================= MATCHES PAGE OVERHAUL (COMMIT 1) ================= */
+
+/* Simplified Match Card */
+.match-card-simplified {
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    border: 1px solid rgba(139, 92, 246, 0.15);
+    background: rgba(13, 18, 38, 0.45);
+    position: relative;
+    overflow: hidden;
+}
+
+.match-card-simplified:hover {
+    transform: translateY(-4px) scale(1.01);
+    border-color: rgba(168, 85, 247, 0.5);
+    background: rgba(18, 25, 53, 0.65);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4), 
+                0 0 20px rgba(139, 92, 246, 0.15);
+}
+
+.match-card-simplified .card-content {
+    position: relative;
+    z-index: 2;
+}
+
+/* Initials Avatar */
+.initials-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 800;
+    font-size: 1.1rem;
+    color: #ffffff;
+    text-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    flex-shrink: 0;
+    background: linear-gradient(135deg, #7c3aed, #3b82f6);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.initials-avatar.lg {
+    width: 80px;
+    height: 80px;
+    font-size: 1.8rem;
+    border-radius: 22px;
+}
+
+/* Glassmorphism Modal */
+.glass-modal .modal-content {
+    background: linear-gradient(145deg, rgba(15, 20, 45, 0.95), rgba(10, 14, 30, 0.98));
+    backdrop-filter: blur(20px) saturate(180%);
+    border: 1px solid rgba(168, 85, 247, 0.25);
+    border-radius: 28px;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.7);
+    color: #ffffff;
+}
+
+.glass-modal .modal-header {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 24px 30px;
+}
+
+.glass-modal .modal-body {
+    padding: 30px;
+}
+
+.glass-modal .modal-footer {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 20px 30px;
+}
+
+.glass-modal .btn-close {
+    filter: invert(1) grayscale(100%) brightness(200%);
+}
+
+/* Modal Internal Layout */
+.match-detail-section {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 18px;
+    padding: 20px;
+    margin-bottom: 20px;
+}
+
+.match-detail-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #a855f7;
+    font-weight: 800;
+    margin-bottom: 12px;
+    display: block;
+}
+
+.overlap-pill {
+    background: rgba(139, 92, 246, 0.15);
+    border: 1px solid rgba(139, 92, 246, 0.3);
+    padding: 4px 12px;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #d8b4fe;
+}
+
+.match-stat-box {
+    text-align: center;
+    padding: 15px;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.match-stat-value {
+    display: block;
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: #ffffff;
+}
+
+.match-stat-label {
+    font-size: 0.7rem;
+    color: #94a3b8;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* Badge Match */
+.badge-match {
+    background: linear-gradient(90deg, #7c3aed, #4f46e5);
+    border: none;
+    padding: 6px 12px;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    box-shadow: 0 4px 10px rgba(124, 58, 237, 0.3);
+}
+

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3813,3 +3813,44 @@ body {
     box-shadow: 0 4px 10px rgba(124, 58, 237, 0.3);
 }
 
+/* Matches Filter Form */
+.matches-filter-form .form-label {
+    color: rgba(235, 239, 255, 0.9);
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.matches-filter-input,
+.matches-filter-select {
+    min-height: 44px;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    background: rgba(11, 18, 36, 0.62);
+    color: #f4f7ff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.matches-filter-input::placeholder {
+    color: rgba(208, 217, 255, 0.55);
+}
+
+.matches-filter-input:focus,
+.matches-filter-select:focus {
+    border-color: rgba(109, 165, 255, 0.75);
+    box-shadow: 0 0 0 0.2rem rgba(109, 165, 255, 0.2);
+    background: rgba(18, 27, 52, 0.82);
+    color: #ffffff;
+}
+
+.matches-filter-select option,
+.matches-filter-select optgroup {
+    background: #101b33;
+    color: #f4f7ff;
+}
+
+.matches-filter-btn {
+    min-height: 44px;
+    border-radius: 12px;
+    font-weight: 600;
+}
+

--- a/app/templates/matches.html
+++ b/app/templates/matches.html
@@ -135,9 +135,9 @@
                 <div class="d-flex justify-content-center gap-3 mt-4">
                     <form id="modalAcceptForm" method="POST" action="" class="m-0">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <button type="submit" class="custom-btn" style="min-width: 180px; text-align: center;">Accept Match</button>
+                        <button type="submit" class="custom-btn" style="min-width: 180px; justify-content: center;">Accept Match</button>
                     </form>
-                    <button id="modalIgnoreBtn" class="custom-btn secondary" style="min-width: 180px; text-align: center;" onclick="">Ignore</button>
+                    <button id="modalIgnoreBtn" class="custom-btn secondary" style="min-width: 180px; justify-content: center;" onclick="">Ignore</button>
                 </div>
             </div>
         </div>

--- a/app/templates/matches.html
+++ b/app/templates/matches.html
@@ -1,48 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Matches{% endblock %}
 {% block head %}
-<style>
-    .sidebar .sidebar-section:nth-of-type(2) {
-        display: none !important;
-    }
-    .sidebar a#editProfileBtn {
-        display: none;
-    }
-    .matches-filter-form .form-label {
-        color: rgba(235, 239, 255, 0.9);
-        font-weight: 600;
-        margin-bottom: 0.5rem;
-    }
-    .matches-filter-input,
-    .matches-filter-select {
-        min-height: 44px;
-        border-radius: 12px;
-        border: 1px solid rgba(255, 255, 255, 0.16);
-        background: rgba(11, 18, 36, 0.62);
-        color: #f4f7ff;
-        transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-    }
-    .matches-filter-input::placeholder {
-        color: rgba(208, 217, 255, 0.55);
-    }
-    .matches-filter-input:focus,
-    .matches-filter-select:focus {
-        border-color: rgba(109, 165, 255, 0.75);
-        box-shadow: 0 0 0 0.2rem rgba(109, 165, 255, 0.2);
-        background: rgba(18, 27, 52, 0.82);
-        color: #ffffff;
-    }
-    .matches-filter-select option,
-    .matches-filter-select optgroup {
-        background: #101b33;
-        color: #f4f7ff;
-    }
-    .matches-filter-btn {
-        min-height: 44px;
-        border-radius: 12px;
-        font-weight: 600;
-    }
-</style>
 {% endblock %}
 {% block content %}
 <div class="page-header">
@@ -83,41 +41,121 @@
     <section class="alert alert-info" role="alert">{{ message }}</section>
 {% endif %}
 {% if matches %}
-    {% for item in matches %}
-        <section class="info-card mb-3">
-            <div class="d-flex justify-content-between align-items-center mb-2">
-                <h5 class="mb-0">{{ item.user.first_name }}</h5>
-                <span class="badge text-bg-primary">{{ item.overlap_minutes_total }} mins overlap</span>
+    <div class="row g-4">
+        {% for item in matches %}
+            <div class="col-12">
+                <section class="info-card match-card-simplified p-4" 
+                         onclick="openMatchModal(this)"
+                         data-user-id="{{ item.user.id }}"
+                         data-name="{{ item.user.first_name }} {{ item.user.last_name }}"
+                         data-username="{{ item.user.username }}"
+                         data-degree="{{ item.user.degree }}"
+                         data-bio="{{ item.user.bio or 'No bio provided.' }}"
+                         data-overlap-minutes="{{ item.overlap_minutes_total }}"
+                         data-shared-units-count="{{ item.shared_unit_count }}"
+                         data-overlap-html="{% for day, segments in item.overlap_by_day.items() %}<li><strong>{{ day }}:</strong> {% for segment in segments %}{{ segment[0] }}-{{ segment[1] }}{% if not loop.last %}, {% endif %}{% endfor %}</li>{% endfor %}"
+                         data-units-html="{% if item.shared_units %}{% for unit in item.shared_units %}<span class='tag'>{{ unit }}</span>{% endfor %}{% else %}<span class='text-muted'>No shared units</span>{% endif %}">
+                    
+                    <div class="card-content d-flex align-items-center justify-content-between">
+                        <div class="d-flex align-items-center gap-3">
+                            <div class="initials-avatar">
+                                {{ item.user.first_name[0] }}{{ item.user.last_name[0] }}
+                            </div>
+                            <div>
+                                <h5 class="mb-1">{{ item.user.first_name }} {{ item.user.last_name }}</h5>
+                                <p class="mb-0 text-muted small">{{ item.user.degree }}</p>
+                            </div>
+                        </div>
+
+                        <div class="d-flex align-items-center gap-3">
+                            <span class="badge badge-match rounded-pill d-none d-md-inline-block">
+                                {{ item.overlap_minutes_total }} mins overlap
+                            </span>
+                            
+                            <div class="d-flex gap-2">
+                                <form method="POST" action="{{ url_for('main.start_conversation', receiver_id=item.user.id) }}" class="m-0" onclick="event.stopPropagation()">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button type="submit" class="custom-btn" style="padding: 8px 16px; font-size: 0.85rem;">
+                                        Accept
+                                    </button>
+                                </form>
+                                <button class="custom-btn secondary" style="padding: 8px 16px; font-size: 0.85rem;" onclick="event.stopPropagation(); ignoreMatch(this, {{ item.user.id }})">
+                                    Ignore
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </section>
             </div>
-            <p class="mb-2"><strong>Degree:</strong> {{ item.user.degree }}</p>
-            <div>
-                <strong>Overlap Summary:</strong>
-                <ul class="mb-0 mt-2">
-                    {% for day, segments in item.overlap_by_day.items() %}
-                        <li>{{ day }}:
-                            {% for segment in segments %}
-                                {{ segment[0] }}-{{ segment[1] }}{% if not loop.last %}, {% endif %}
-                            {% endfor %}
-                        </li>
-                    {% endfor %}
-                </ul>
-            </div>
-            
-            <!-- Accept/Ignore buttons -->
-            <div style="display: flex; gap: 10px; margin-top: 16px;">
-                <form method="POST" action="{{ url_for('main.start_conversation', receiver_id=item.user.id) }}" style="display:inline">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <button type="submit" class="custom-btn">
-                        <i class="bi bi-check2"></i> Accept
-                    </button>
-                </form>
-                <button class="custom-btn secondary" onclick="ignoreMatch(this, {{ item.user.id }})">
-                    <i class="bi bi-x"></i> Ignore
-                </button>
-            </div>
-        </section>
-{% endfor %}
+        {% endfor %}
+    </div>
 {% endif %}
+
+<!-- Profile Detail Modal -->
+<div class="modal fade glass-modal" id="matchDetailModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+            <div class="modal-header border-0 pb-0">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row align-items-center mb-4">
+                    <div class="col-auto">
+                        <div id="modalAvatar" class="initials-avatar lg"></div>
+                    </div>
+                    <div class="col">
+                        <h2 id="modalName" class="mb-1"></h2>
+                        <p id="modalDegree" class="text-muted mb-0"></p>
+                    </div>
+                </div>
+
+                <div class="row g-3 mb-4">
+                    <div class="col-md-6">
+                        <div class="match-stat-box">
+                            <span class="match-stat-label">Overlap Time</span>
+                            <span id="modalOverlapMins" class="match-stat-value"></span>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="match-stat-box">
+                            <span class="match-stat-label">Shared Units</span>
+                            <span id="modalUnitsCount" class="match-stat-value"></span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="match-detail-section">
+                    <span class="match-detail-label">Bio</span>
+                    <p id="modalBio" class="mb-0"></p>
+                </div>
+
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <div class="match-detail-section h-100 mb-0">
+                            <span class="match-detail-label">Common Units</span>
+                            <div id="modalUnitsList" class="d-flex flex-wrap gap-1"></div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="match-detail-section h-100 mb-0">
+                            <span class="match-detail-label">Overlap Schedule</span>
+                            <ul id="modalOverlapList" class="list-unstyled mb-0 small"></ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer border-0">
+                <div class="d-flex gap-3 w-100">
+                    <form id="modalAcceptForm" method="POST" action="" class="flex-grow-1 m-0">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="custom-btn w-100">Accept Match</button>
+                    </form>
+                    <button id="modalIgnoreBtn" class="custom-btn secondary flex-grow-1" onclick="">Ignore</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}
 {% block scripts %}
 <script>

--- a/app/templates/matches.html
+++ b/app/templates/matches.html
@@ -160,14 +160,51 @@
 {% block scripts %}
 <script>
 const csrfToken = "{{ csrf_token() }}";
+let activeCard = null;
 
-function ignoreMatch(btn, userId) {
-    const card = btn.closest('section.info-card');
+function openMatchModal(card) {
+    activeCard = card;
+    const data = card.dataset;
+    const modal = new bootstrap.Modal(document.getElementById('matchDetailModal'));
+    
+    // Populate text fields
+    document.getElementById('modalName').textContent = data.name;
+    document.getElementById('modalDegree').textContent = data.degree;
+    document.getElementById('modalBio').textContent = data.bio;
+    document.getElementById('modalOverlapMins').textContent = data.overlapMinutes + 'm';
+    document.getElementById('modalUnitsCount').textContent = data.sharedUnitsCount;
+    
+    // Populate HTML fields
+    document.getElementById('modalUnitsList').innerHTML = data.unitsHtml;
+    document.getElementById('modalOverlapList').innerHTML = data.overlapHtml;
+    
+    // Avatar
+    const initials = data.name.split(' ').map(n => n[0]).join('').toUpperCase();
+    document.getElementById('modalAvatar').textContent = initials;
+    
+    // Form Action for Accept
+    const acceptForm = document.getElementById('modalAcceptForm');
+    acceptForm.action = `/messages/start/${data.userId}`;
+    
+    // Ignore button handler
+    const ignoreBtn = document.getElementById('modalIgnoreBtn');
+    ignoreBtn.onclick = () => {
+        ignoreMatch(card, data.userId);
+        modal.hide();
+    };
+    
+    modal.show();
+}
+
+function ignoreMatch(btnOrCard, userId) {
+    const card = btnOrCard.classList.contains('info-card') ? btnOrCard : btnOrCard.closest('section.info-card');
     if (!card) return;
+    
     card.style.transition = 'opacity 0.25s, transform 0.25s';
     card.style.opacity = '0';
     card.style.transform = 'scale(0.97)';
     setTimeout(() => { card.style.display = 'none'; }, 260);
+    
     fetch(`/matches/ignore/${userId}`, {
         method: 'POST',
         headers: { 'X-CSRFToken': csrfToken }

--- a/app/templates/matches.html
+++ b/app/templates/matches.html
@@ -109,36 +109,24 @@
                     </div>
                 </div>
 
-                <div class="row g-3 mb-4">
-                    <div class="col-md-6">
-                        <div class="match-stat-box">
-                            <span class="match-stat-label">Overlap Time</span>
-                            <span id="modalOverlapMins" class="match-stat-value"></span>
-                        </div>
-                    </div>
-                    <div class="col-md-6">
-                        <div class="match-stat-box">
-                            <span class="match-stat-label">Shared Units</span>
-                            <span id="modalUnitsCount" class="match-stat-value"></span>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="match-detail-section">
+                <div class="match-detail-section mb-4">
                     <span class="match-detail-label">Bio</span>
                     <p id="modalBio" class="mb-0"></p>
                 </div>
 
                 <div class="row g-3">
-                    <div class="col-md-6">
+                    <div class="col-md-5">
                         <div class="match-detail-section h-100 mb-0">
                             <span class="match-detail-label">Common Units</span>
                             <div id="modalUnitsList" class="d-flex flex-wrap gap-1"></div>
                         </div>
                     </div>
-                    <div class="col-md-6">
+                    <div class="col-md-7">
                         <div class="match-detail-section h-100 mb-0">
-                            <span class="match-detail-label">Overlap Schedule</span>
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <span class="match-detail-label mb-0">Shared Times</span>
+                                <span id="modalOverlapMins" class="badge badge-match rounded-pill"></span>
+                            </div>
                             <ul id="modalOverlapList" class="list-unstyled mb-0 small"></ul>
                         </div>
                     </div>
@@ -172,7 +160,6 @@ function openMatchModal(card) {
     document.getElementById('modalDegree').textContent = data.degree;
     document.getElementById('modalBio').textContent = data.bio;
     document.getElementById('modalOverlapMins').textContent = data.overlapMinutes + 'm';
-    document.getElementById('modalUnitsCount').textContent = data.sharedUnitsCount;
     
     // Populate HTML fields
     document.getElementById('modalUnitsList').innerHTML = data.unitsHtml;

--- a/app/templates/matches.html
+++ b/app/templates/matches.html
@@ -114,31 +114,30 @@
                     <p id="modalBio" class="mb-0"></p>
                 </div>
 
-                <div class="row g-3">
-                    <div class="col-md-5">
+                <div class="row g-3 mb-4">
+                    <div class="col-md-6">
                         <div class="match-detail-section h-100 mb-0">
                             <span class="match-detail-label">Common Units</span>
                             <div id="modalUnitsList" class="d-flex flex-wrap gap-1"></div>
                         </div>
                     </div>
-                    <div class="col-md-7">
+                    <div class="col-md-6">
                         <div class="match-detail-section h-100 mb-0">
                             <div class="d-flex justify-content-between align-items-center mb-2">
                                 <span class="match-detail-label mb-0">Shared Times</span>
-                                <span id="modalOverlapMins" class="badge badge-match rounded-pill"></span>
                             </div>
                             <ul id="modalOverlapList" class="list-unstyled mb-0 small"></ul>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class="modal-footer border-0">
-                <div class="d-flex gap-3 w-100">
-                    <form id="modalAcceptForm" method="POST" action="" class="flex-grow-1 m-0">
+
+                <!-- Modal Actions -->
+                <div class="d-flex justify-content-center gap-3 mt-4">
+                    <form id="modalAcceptForm" method="POST" action="" class="m-0">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <button type="submit" class="custom-btn w-100">Accept Match</button>
+                        <button type="submit" class="custom-btn" style="min-width: 180px; text-align: center;">Accept Match</button>
                     </form>
-                    <button id="modalIgnoreBtn" class="custom-btn secondary flex-grow-1" onclick="">Ignore</button>
+                    <button id="modalIgnoreBtn" class="custom-btn secondary" style="min-width: 180px; text-align: center;" onclick="">Ignore</button>
                 </div>
             </div>
         </div>
@@ -159,7 +158,6 @@ function openMatchModal(card) {
     document.getElementById('modalName').textContent = data.name;
     document.getElementById('modalDegree').textContent = data.degree;
     document.getElementById('modalBio').textContent = data.bio;
-    document.getElementById('modalOverlapMins').textContent = data.overlapMinutes + 'm';
     
     // Populate HTML fields
     document.getElementById('modalUnitsList').innerHTML = data.unitsHtml;


### PR DESCRIPTION
Reworked match search results to first show a very brief summary,
<img width="1127" height="659" alt="Screenshot 2026-05-16 161038" src="https://github.com/user-attachments/assets/b267d842-d129-49ad-aa68-59ac37809ae0" />

and then clicking on it opens a popup where the user can see more details.
<img width="953" height="504" alt="image" src="https://github.com/user-attachments/assets/a65fd99c-dd39-4a5b-b9d4-e6f9faa1159f" />


Accept/ignore buttons behaviour kept same from previous.