### PR TITLE
Update onboarding flow for new sidebar steps

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -49,16 +49,20 @@ UNIT_CODE_PATTERN = re.compile(r"^[A-Z]{4}[0-9]{4}$")
 ONBOARDING_STEP_ENDPOINTS = {
     1: "dashboard",
     2: "matches",
-    3: "messages_inbox",
-    4: "events_page",
-    5: "profile",
+    3: "people",
+    4: "messages_inbox",
+    5: "events_page",
+    6: "notifications",
+    7: "profile",
 }
 ONBOARDING_STEP_COPY = {
     1: "This is your dashboard. You can track upcoming meetings and suggested matches here.",
     2: "This is matches. StudySync ranks people by overlapping availability and profile fit.",
-    3: "This is messages. Use it to chat and coordinate study sessions.",
-    4: "This is events. Create or join sessions to plan study time.",
-    5: "This is profile. Add at least one unit and one availability slot, then finish onboarding.",
+    3: "This is people. Search students and send friend requests before starting conversations.",
+    4: "This is messages. Use it to chat and coordinate study sessions.",
+    5: "This is events. Create or join sessions to plan study time.",
+    6: "This is notifications. Track invites, mentions, and request updates in one place.",
+    7: "This is profile. Add at least one unit and one availability slot, then finish onboarding.",
 }
 
 
@@ -254,7 +258,8 @@ def require_onboarding_completion():
         return None
     if request.endpoint is None:
         return None
-    allowed_endpoints = {"main.onboarding", "main.onboarding_advance", "main.logout", "static"}
+    onboarding_nav_endpoints = {f"main.{endpoint}" for endpoint in ONBOARDING_STEP_ENDPOINTS.values()}
+    allowed_endpoints = {"main.onboarding", "main.onboarding_advance", "main.logout", "static"}.union(onboarding_nav_endpoints)
     if request.endpoint in allowed_endpoints:
         return None
     target_endpoint = f"main.{get_onboarding_target_endpoint(current_user)}"

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -142,7 +142,7 @@
                 </div>
 
                 <ol class="onboarding-guide__steps" aria-label="Onboarding steps">
-                    {% for label in ["Dashboard", "Matches", "Messages", "Events", "Profile"] %}
+                    {% for label in ["Dashboard", "Matches", "People", "Messages", "Events", "Notifications", "Profile"] %}
                     <li class="onboarding-guide__step {% if loop.index == onboarding_guide.step %}is-current{% elif loop.index < onboarding_guide.step %}is-complete{% endif %}">
                         <span class="onboarding-guide__dot"></span>
                         <span class="onboarding-guide__label">{{ label }}</span>

--- a/tests/test_profile_unit.py
+++ b/tests/test_profile_unit.py
@@ -262,5 +262,70 @@ class ProfileUnitTests(unittest.TestCase):
             self.assertIsNotNone(avail)
             self.assertEqual(avail.start_time, "09:00")
 
+    def test_onboarding_next_follows_sidebar_sequence(self):
+        with app.app_context():
+            ordered_user = User(
+                first_name="Order",
+                last_name="User",
+                email="order@test.com",
+                username="orderuser",
+                degree="Bachelor of Science",
+                major="Computer Science",
+                onboarding_completed=False,
+                onboarding_step=1,
+            )
+            ordered_user.set_password("password123")
+            db.session.add(ordered_user)
+            db.session.commit()
+
+        self.client.post(
+            "/login",
+            data={"username": "orderuser", "password": "password123"},
+            follow_redirects=True,
+        )
+
+        expected_locations = [
+            "/matches",
+            "/people",
+            "/messages",
+            "/events",
+            "/notifications",
+            "/profile",
+        ]
+
+        for expected in expected_locations:
+            response = self.client.post(
+                "/onboarding/advance",
+                data={"action": "next"},
+                follow_redirects=False,
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertIn(expected, response.headers.get("Location", ""))
+
+    def test_notifications_page_accessible_during_onboarding(self):
+        with app.app_context():
+            nav_user = User(
+                first_name="Nav",
+                last_name="User",
+                email="nav@test.com",
+                username="navuser",
+                degree="Bachelor of Science",
+                major="Computer Science",
+                onboarding_completed=False,
+                onboarding_step=6,
+            )
+            nav_user.set_password("password123")
+            db.session.add(nav_user)
+            db.session.commit()
+
+        self.client.post(
+            "/login",
+            data={"username": "navuser", "password": "password123"},
+            follow_redirects=True,
+        )
+
+        response = self.client.get("/notifications", follow_redirects=False)
+        self.assertEqual(response.status_code, 200)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Updated onboarding to match the expanded app navigation and fixed the routing lock that trapped users on certain pages. The flow now includes People and Notifications, still ends on Profile, and allows navigation between onboarding sidebar pages. Added unit tests to verify step order progression and Notifications page access during onboarding.