### PR TITLE
Add unfriend feature to friends section

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1578,6 +1578,36 @@ def cancel_friend_request(friend_request_id):
     flash("Friend request cancelled.", "info")
     return redirect(url_for("main.people", tab="friends"))
 
+@main_bp.route("/friends/<int:user_id>/remove", methods=["POST"])
+@login_required
+def unfriend_user(user_id):
+
+    friend_request = FriendRequest.query.filter_by(status="accepted").filter(
+        or_(
+            db.and_(
+                FriendRequest.user_low_id == current_user.id,
+                FriendRequest.user_high_id == user_id,
+            ),
+            db.and_(
+                FriendRequest.user_high_id == current_user.id,
+                FriendRequest.user_low_id == user_id,
+            ),
+        )
+    ).first()
+
+    if friend_request is None:
+        flash("Friendship not found.", "error")
+        return redirect(url_for("main.people", tab="friends"))
+
+    db.session.delete(friend_request)
+
+    db.session.commit()
+
+    flash("Friend removed.", "success")
+
+    return redirect(url_for("main.people", tab="friends"))
+
+
 
 @main_bp.route("/profile", methods=["GET", "POST"])
 @login_required

--- a/app/static/css/pages/people.css
+++ b/app/static/css/pages/people.css
@@ -143,3 +143,18 @@
     }
 }
 
+.friends-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 16px;
+}
+
+.friends-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+
+

--- a/app/templates/people.html
+++ b/app/templates/people.html
@@ -89,9 +89,9 @@
                 <h5>Incoming Requests</h5>
                 {% if incoming_requests %}
                     {% for row in incoming_requests %}
-                    <div class="mt-3 d-flex justify-content-between align-items-center gap-2 flex-wrap">
+                    <div class="mt-3 d-flex justify-content-between align-items-center">
                         <div>{{ row.user.username if row.user else 'Unknown user' }}</div>
-                        <div class="d-flex gap-2">
+                        <div class="d-flex align-items-center gap-2">
                             <form method="POST" action="{{ url_for('main.accept_friend_request', friend_request_id=row.request.id) }}">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                 <button type="submit" class="btn btn-success btn-sm">Accept</button>
@@ -115,7 +115,9 @@
                 {% if outgoing_requests %}
                     {% for row in outgoing_requests %}
                     <div class="mt-3 d-flex justify-content-between align-items-center gap-2 flex-wrap">
-                        <div>{{ row.user.username if row.user else 'Unknown user' }}</div>
+                        <div class="fw-semibold">
+                            {{ row.user.username if row.user else 'Unknown user' }}
+                        </div>
                         <form method="POST" action="{{ url_for('main.cancel_friend_request', friend_request_id=row.request.id) }}">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <button type="submit" class="btn btn-outline-warning btn-sm">Cancel</button>
@@ -142,6 +144,12 @@
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <button type="submit" class="btn btn-outline-light btn-sm">Message</button>
                         </form>
+                        <form method="POST" action="{{ url_for('main.unfriend_user', user_id=row.user.id) }}">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="btn btn-outline-danger btn-sm">Unfriend</button>
+                        </form>
+                    </div>
+                    
                         {% endif %}
                     </div>
                     {% endfor %}


### PR DESCRIPTION
In the Friends section of the People page, users can now unfriend an existing friend. When one user unfriends another, no notification is sent, but both users are removed from each other’s friend lists.